### PR TITLE
fix(web): renamed 2 labels on driver profile page

### DIFF
--- a/frontend/FleetForge/src/app/profiles/user-profile-driver/user-profile-driver.component.html
+++ b/frontend/FleetForge/src/app/profiles/user-profile-driver/user-profile-driver.component.html
@@ -35,10 +35,10 @@
 <div>
     <span>Vehicle</span>
   <form [formGroup]="editVehicleInfo" (ngSubmit)="editVehicle()">
-    <label for="model">Car name</label>
+    <label for="model">Model</label>
     <input id="model" formControlName="model" placeholder="Enter your car name" required>
 
-    <label for="type">Engine number</label>
+    <label for="type">Vehicle type</label>
     <select id="type" formControlName="type" required>
       <option value="" disabled selected>Select vehicle type</option>
       <option value="standard">Standard</option>


### PR DESCRIPTION
Renamed 2 labels on driver profile page to model and vehicle type from car name and engine number.