### PR TITLE
Feature/ride estimate api endpoint

### DIFF
--- a/backend/FleetForge/pom.xml
+++ b/backend/FleetForge/pom.xml
@@ -45,7 +45,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
 
 	<build>
 		<plugins>

--- a/backend/FleetForge/src/main/java/com/team18/FleetForge/controller/RideEstimateController.java
+++ b/backend/FleetForge/src/main/java/com/team18/FleetForge/controller/RideEstimateController.java
@@ -1,0 +1,45 @@
+package com.team18.FleetForge.controller;
+
+
+import com.team18.FleetForge.dto.RideEstimateRequestDTO;
+import com.team18.FleetForge.dto.RideEstimateResponseDTO;
+import com.team18.FleetForge.dto.RouteDTO;
+import com.team18.FleetForge.model.GeoPoint;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/ride-estimates")
+public class RideEstimateController {
+
+    @PostMapping(
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<RideEstimateResponseDTO> estimateRide(
+            @RequestBody RideEstimateRequestDTO request
+    ) {
+        // Dummy geometry (as returned by OSM-based routers)
+        List<GeoPoint> geometry = List.of(
+                request.getStartLocation(),
+                new GeoPoint(45.2685, 19.8400),
+                new GeoPoint(45.2700, 19.8500),
+                request.getDestinationLocation()
+        );
+
+        RouteDTO route = new RouteDTO();
+        route.setGeometry(geometry);
+        route.setDistanceMeters(5200);
+        route.setDurationSeconds(900);
+
+        RideEstimateResponseDTO response = new RideEstimateResponseDTO();
+        response.setRoute(route);
+        response.setEstimatedCost(780.00);
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+}

--- a/backend/FleetForge/src/main/java/com/team18/FleetForge/dto/RideEstimateRequestDTO.java
+++ b/backend/FleetForge/src/main/java/com/team18/FleetForge/dto/RideEstimateRequestDTO.java
@@ -1,0 +1,16 @@
+package com.team18.FleetForge.dto;
+
+import com.team18.FleetForge.model.GeoPoint;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class RideEstimateRequestDTO {
+
+    private GeoPoint startLocation;
+    private GeoPoint destinationLocation;
+
+    // Optional waypoints
+    private List<GeoPoint> waypoints;
+}

--- a/backend/FleetForge/src/main/java/com/team18/FleetForge/dto/RideEstimateResponseDTO.java
+++ b/backend/FleetForge/src/main/java/com/team18/FleetForge/dto/RideEstimateResponseDTO.java
@@ -1,0 +1,11 @@
+package com.team18.FleetForge.dto;
+
+import lombok.Data;
+
+@Data
+public class RideEstimateResponseDTO {
+
+    private RouteDTO route;
+
+    private double estimatedCost;
+}

--- a/backend/FleetForge/src/main/java/com/team18/FleetForge/dto/RouteDTO.java
+++ b/backend/FleetForge/src/main/java/com/team18/FleetForge/dto/RouteDTO.java
@@ -1,0 +1,15 @@
+package com.team18.FleetForge.dto;
+
+import com.team18.FleetForge.model.GeoPoint;
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class RouteDTO {
+
+    private List<GeoPoint> geometry;
+
+    private double distanceMeters;
+
+    private double durationSeconds;
+}

--- a/backend/FleetForge/src/main/java/com/team18/FleetForge/model/GeoPoint.java
+++ b/backend/FleetForge/src/main/java/com/team18/FleetForge/model/GeoPoint.java
@@ -1,0 +1,14 @@
+package com.team18.FleetForge.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GeoPoint {
+
+    private double latitude;
+    private double longitude;
+}

--- a/backend/FleetForge/src/test/resources/ride-estimate.http
+++ b/backend/FleetForge/src/test/resources/ride-estimate.http
@@ -1,0 +1,17 @@
+POST http://localhost:8080/api/ride-estimates
+Content-Type: application/json
+
+{
+  "startLocation": {
+    "latitude": 45.2671,
+    "longitude": 19.8335
+  },
+  "destinationLocation": {
+    "latitude": 45.2710,
+    "longitude": 19.8520
+  },
+  "waypoints": [
+    { "latitude": 45.2680, "longitude": 19.8400 },
+    { "latitude": 45.2690, "longitude": 19.8450 }
+  ]
+}


### PR DESCRIPTION
**Target Branch:** `develop`  
**Source Branch:** `feature/ride-estimate-api-endpoint`

This pull request introduces the initial **ride estimate API endpoint**, establishing the foundation for trip calculation functionality with dummy data for immediate testing.

### Changes:
- **Ride Estimate Endpoint**: Implemented POST `/api/ride-estimates` endpoint with request/response DTOs
- **Dummy Data**: Returns static estimates for distance, duration, and cost (to be replaced with real calculation in future)

### Closes
- Closes #28 