### PR TITLE
Feature/ride start complete flow mobile

### DIFF
--- a/mobile/app/src/main/java/com/ognjen/fleetforge/api/RideService.java
+++ b/mobile/app/src/main/java/com/ognjen/fleetforge/api/RideService.java
@@ -2,13 +2,18 @@ package com.ognjen.fleetforge.api;
 
 import com.ognjen.fleetforge.dtos.ride.RideCreateRequestDTO;
 import com.ognjen.fleetforge.dtos.ride.RideCreateResponseDTO;
+import com.ognjen.fleetforge.dtos.ride.RideStartResponseDTO;
 
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.POST;
+import retrofit2.http.PUT;
+import retrofit2.http.Path;
 
 public interface RideService {
 
     @POST("/api/rides/create")
     Call<RideCreateResponseDTO> createRide(@Body RideCreateRequestDTO request);
+    @PUT("/api/rides/{id}/start")
+    Call<RideStartResponseDTO> startRide(@Path("id") Long id);
 }

--- a/mobile/app/src/main/java/com/ognjen/fleetforge/dtos/ride/RideStartResponseDTO.java
+++ b/mobile/app/src/main/java/com/ognjen/fleetforge/dtos/ride/RideStartResponseDTO.java
@@ -1,0 +1,24 @@
+package com.ognjen.fleetforge.dtos.ride;
+
+import com.ognjen.fleetforge.enums.RideStatus;
+
+public class RideStartResponseDTO {
+    private Long id;
+    private RideStatus status;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public RideStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(RideStatus status) {
+        this.status = status;
+    }
+}

--- a/mobile/app/src/main/java/com/ognjen/fleetforge/enums/RideStatus.java
+++ b/mobile/app/src/main/java/com/ognjen/fleetforge/enums/RideStatus.java
@@ -1,0 +1,8 @@
+package com.ognjen.fleetforge.enums;
+
+public enum RideStatus {
+    ACCEPTED,
+    IN_PROGRESS,
+    COMPLETED,
+    CANCELLED
+}

--- a/mobile/app/src/main/java/com/ognjen/fleetforge/fragments/driver/CurrentRideDriver.java
+++ b/mobile/app/src/main/java/com/ognjen/fleetforge/fragments/driver/CurrentRideDriver.java
@@ -16,6 +16,7 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
 
 import com.ognjen.fleetforge.BuildConfig;
 import com.ognjen.fleetforge.R;
@@ -79,6 +80,13 @@ public class CurrentRideDriver extends Fragment {
     private static final int SIMULATION_STEP_SIZE = 5; // Skip 5 coordinates per update
     private static final double WAYPOINT_THRESHOLD = 0.0005; // ~50 meters
 
+    private CurrentRideDriverViewModel viewModel;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        viewModel=new ViewModelProvider(this).get(CurrentRideDriverViewModel.class);
+    }
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
@@ -553,7 +561,14 @@ public class CurrentRideDriver extends Fragment {
 
 
     private void onPrimaryActionClick() {
-        Toast.makeText(requireContext(), "Primary action clicked", Toast.LENGTH_SHORT).show();
+        if(btnPrimaryAction.getText().equals("Start Ride")){
+            viewModel.startRide(currentRide.getRideId()).observe(getViewLifecycleOwner(),response->{
+                if(response!=null){
+                    fetchActiveRide();
+                    Toast.makeText(requireContext(), "Ride with id: "+response.getId()+" started. Status: "+response.getStatus(), Toast.LENGTH_SHORT).show();
+                }
+            });
+        }
     }
 
     private void onSecondaryActionClick() {

--- a/mobile/app/src/main/java/com/ognjen/fleetforge/fragments/driver/CurrentRideDriverViewModel.java
+++ b/mobile/app/src/main/java/com/ognjen/fleetforge/fragments/driver/CurrentRideDriverViewModel.java
@@ -1,0 +1,19 @@
+package com.ognjen.fleetforge.fragments.driver;
+
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.ViewModel;
+
+import com.ognjen.fleetforge.dtos.ride.RideStartResponseDTO;
+import com.ognjen.fleetforge.repository.RideRepo;
+
+public class CurrentRideDriverViewModel extends ViewModel {
+    private RideRepo repo;
+
+    public CurrentRideDriverViewModel(){
+        repo= new RideRepo();
+    }
+
+    public LiveData<RideStartResponseDTO> startRide(Long id){
+        return repo.startRide(id);
+    }
+}

--- a/mobile/app/src/main/java/com/ognjen/fleetforge/repository/RideRepo.java
+++ b/mobile/app/src/main/java/com/ognjen/fleetforge/repository/RideRepo.java
@@ -8,6 +8,7 @@ import com.ognjen.fleetforge.api.RetrofitClient;
 import com.ognjen.fleetforge.api.RideService;
 import com.ognjen.fleetforge.dtos.ride.RideCreateRequestDTO;
 import com.ognjen.fleetforge.dtos.ride.RideCreateResponseDTO;
+import com.ognjen.fleetforge.dtos.ride.RideStartResponseDTO;
 
 import retrofit2.Call;
 import retrofit2.Callback;
@@ -38,6 +39,30 @@ public class RideRepo {
 
             @Override
             public void onFailure(Call<RideCreateResponseDTO> call, Throwable throwable) {
+                android.util.Log.e("API_FAILURE", "Doslo je do greske: ", throwable);
+                data.setValue(null);
+            }
+        });
+        return data;
+    }
+    public LiveData<RideStartResponseDTO> startRide(Long id){
+        MutableLiveData<RideStartResponseDTO> data= new MutableLiveData<>();
+
+        service.startRide(id).enqueue(new Callback<RideStartResponseDTO>() {
+            @Override
+            public void onResponse(Call<RideStartResponseDTO> call, Response<RideStartResponseDTO> response) {
+                if(response.isSuccessful()){
+                    data.setValue(response.body());
+                }else{
+                    try {
+                        android.util.Log.e("API_ERROR", "Error body: " + response.errorBody().string());
+                    } catch (Exception e) { e.printStackTrace(); }
+                    data.setValue(null);
+                }
+            }
+
+            @Override
+            public void onFailure(Call<RideStartResponseDTO> call, Throwable throwable) {
                 android.util.Log.e("API_FAILURE", "Doslo je do greske: ", throwable);
                 data.setValue(null);
             }


### PR DESCRIPTION
## 🚗 Feature: Ride Start Flow (Driver – Mobile)

### Summary
This PR implements the **ride start flow for drivers** on the mobile app.
It introduces the necessary DTOs, enums, ViewModel, repository, and service logic to enable starting a ride via backend integration, following the MVVM architecture.

---

### ✨ Key Features
- Driver can start the current ride from the mobile app
- Ride status handling through enum
- Full request–response flow wired to backend
- Clear separation of responsibilities (ViewModel → Repo → Service)

---

### 🏗️ Technical Details
- Added new DTO and enum:
  - `RideStartResponseDTO`
  - `RideStatus`
- Implemented `CurrentRideDriverViewModel`
- Extended ride flow through:
  - `RideService`
  - `RideRepo`
- Updated `CurrentRideDriver` fragment to use ViewModel logic
- Backend communication handled via Retrofit and LiveData

---

### 🧪 Notes
- This PR focuses on **starting** the ride
- Ride completion and additional ride state handling can be extended on top of this flow
- Backend endpoints are assumed to be available and functional

---

### Closes #236 
