### PR TITLE
Test/e2e favorite routes ride order

### DIFF
--- a/backend/FleetForge/src/main/java/com/team18/FleetForge/config/DataLoader.java
+++ b/backend/FleetForge/src/main/java/com/team18/FleetForge/config/DataLoader.java
@@ -419,11 +419,6 @@ public class DataLoader implements CommandLineRunner {
         rideReviewRepository.save(review);
 
 
-        FavoriteRoute route=new FavoriteRoute();
-        route.setRide(ride1);
-        route.setPassenger(passenger1);
-        route.setName("Home-work");
-        favoriteRouteRepo.save(route);
 
 
         Chat chat1 = Chat.builder()

--- a/e2e-tests/src/test/java/pages/FavoriteRoutesPage.java
+++ b/e2e-tests/src/test/java/pages/FavoriteRoutesPage.java
@@ -1,0 +1,90 @@
+package pages;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated;
+
+public class FavoriteRoutesPage {
+    private WebDriver driver;
+    private WebDriverWait wait;
+
+    @FindBy(xpath = "//table//button[normalize-space(text())='Ride again']")
+    private List<WebElement> rideAgainBtns;
+    @FindBy(tagName = "h2")
+    private WebElement title;
+
+    @FindBy(xpath = "//table//button[normalize-space(text())='Remove']")
+    private WebElement removeBtns;
+
+    @FindBy(xpath = "//table[//div[text()='Home->Gym']]//div[contains(@class,'first-address')]")
+    private WebElement firstAddress;
+    @FindBy(xpath = "//table[//div[text()='Home->Gym']]//div[contains(@class,'last-address')]")
+    private WebElement lastAddress;
+    @FindBy(xpath = "//table[//div[text()='Home->Gym']]//div[contains(@class,'waypoint-chip')]")
+    private List<WebElement> waypoints=new ArrayList<>();
+
+    public static String startAddressOrdered;
+    public static String endAddressOrdered;
+    public static List<String> waypointsOrdered=new ArrayList<>();
+    public FavoriteRoutesPage(WebDriver driver){
+        this.driver=driver;
+        PageFactory.initElements(driver,this);
+        wait= new WebDriverWait(driver,3);
+    }
+
+    public boolean favoriteRoutesPageLoaded()
+    {
+        try{
+            wait.until(ExpectedConditions.textToBePresentInElement(title,"Favorite routes"));
+            return true;
+        }catch (TimeoutException e){
+            return false;
+        }
+    }
+    public boolean favoriteRouteAdded(){
+        try {
+            wait.until(visibilityOfElementLocated(By.xpath("//table//div[text()='Home->Gym']")));
+            return true;
+        }catch (TimeoutException e){
+            return false;
+        }
+    }
+
+    public void orderRouteAgain(){
+
+        wait.until(ExpectedConditions.visibilityOfElementLocated(
+                By.xpath("//table//tr[.//div[text()='Home->Gym']]//button[normalize-space(text())='Ride again']")));
+        WebElement rideAgain=driver.findElement(By.xpath("//table//tr[.//div[text()='Home->Gym']]//button[normalize-space(text())='Ride again']"));
+        startAddressOrdered=firstAddress.getText();
+        endAddressOrdered=lastAddress.getText();
+        waypointsOrdered.clear();
+        for(WebElement element:waypoints){
+            String text = element.getText().trim().replaceAll("[^\\p{L}\\p{N}\\s,.]", "").trim();
+            waypointsOrdered.add(text);
+        }
+        rideAgain.click();
+    }
+    public boolean removeFavoriteRoute(){
+        try {
+            wait.until(ExpectedConditions.elementToBeClickable(
+                    By.xpath("//table//tr[.//div[text()='Home->Gym']]//button[normalize-space(text())='Remove']"))).click();
+            wait.until(ExpectedConditions.invisibilityOfElementLocated(
+                    By.xpath("//table//div[text()='Home->Gym']")));
+            return true;
+        }
+        catch (TimeoutException t){
+            return false;
+        }
+    }
+
+}

--- a/e2e-tests/src/test/java/pages/PassengerHomePage.java
+++ b/e2e-tests/src/test/java/pages/PassengerHomePage.java
@@ -1,0 +1,275 @@
+package pages;
+
+import org.openqa.selenium.*;
+import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.Select;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Objects;
+
+public class PassengerHomePage {
+
+    private WebDriver driver;
+    private WebDriverWait wait;
+
+    @FindBy(id = "sidebarBtn")
+    private WebElement sidebar;
+
+    @FindBy(xpath = "//a[span[text()='Favourite Rides']]")
+    private WebElement favoriteRoutesLink;
+
+    @FindBy(xpath = "//a[span[text()='Ride History']]")
+    private WebElement rideHistoryLink;
+
+    @FindBy(xpath = "//app-navbar//div[text()='Hello, passenger']")
+    private WebElement passengerTitle;
+
+    @FindBy(id = "passengers")
+    private WebElement passengersInput;
+
+    @FindBy(id = "now")
+    private WebElement nowCheckBox;
+
+    @FindBy(id = "type")
+    private WebElement vehicleType;
+
+    @FindBy(xpath = "//form//button[@type='submit']")
+    private WebElement submitBtn;
+
+    @FindBy(id = "babySeat")
+    private WebElement babySeatCB;
+
+    @FindBy(id = "datetime")
+    private WebElement datetime;
+
+    @FindBy(id="pickup")
+    private WebElement pickup;
+
+    @FindBy(id = "dropoff")
+    private WebElement dropoff;
+
+    @FindBy(xpath = "//form//input[contains(@placeholder,'Enter waypoint')]")
+    private List<WebElement> waypointFields;
+
+    public PassengerHomePage(WebDriver driver){
+        this.driver= driver;
+        wait= new WebDriverWait(driver, 10);
+        PageFactory.initElements(driver,this);
+    }
+
+    public boolean isLoaded(){
+        try {
+            wait.until(ExpectedConditions.visibilityOf(passengerTitle));
+            return true;
+        } catch (TimeoutException e) {
+            return false;
+        }
+    }
+
+    public void goToPassengerHistory(){
+        sidebar.click();
+        wait.until(ExpectedConditions.elementToBeClickable(rideHistoryLink)).click();
+    }
+
+    public void goToFavoritesPage(){
+        sidebar.click();
+        wait.until(ExpectedConditions.elementToBeClickable(favoriteRoutesLink)).click();
+    }
+    public boolean areAllCoordinatesFilled(){
+        try{
+            wait.until(ExpectedConditions.elementToBeClickable(submitBtn));
+            wait.until(ExpectedConditions.not(ExpectedConditions.textToBePresentInElement(submitBtn, "Calculating route...")));
+
+            if(Objects.equals(pickup.getAttribute("value"), FavoriteRoutesPage.startAddressOrdered)
+                    && Objects.equals(dropoff.getAttribute("value"),FavoriteRoutesPage.endAddressOrdered)){
+                if(FavoriteRoutesPage.waypointsOrdered.isEmpty())
+                    return true;
+                for(WebElement waypointField : waypointFields){
+                    String value = waypointField.getAttribute("value");
+                    if(!FavoriteRoutesPage.waypointsOrdered.contains(value)){
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }catch (TimeoutException t){
+            return false;
+        }
+    }
+
+/// /////////////////////////////////////////////////////////////////////////////
+
+//    public void fillOrderFormAndOrder(){
+//        passengersInput.sendKeys(Keys.CONTROL+"a");
+//        passengersInput.sendKeys(Keys.DELETE);
+//        passengersInput.sendKeys("2");
+//        nowCheckBox.click();
+//        Select vehicleTypeSelect=new Select(vehicleType);
+//        vehicleTypeSelect.selectByValue("STANDARD");
+//        wait.until(ExpectedConditions.elementToBeClickable(submitBtn));
+//
+//        wait.until(ExpectedConditions.not(ExpectedConditions.textToBePresentInElement(submitBtn, "Calculating route...")));
+//
+//        submitBtn.click();
+//    }
+//
+//    public boolean isOrdered(){
+//        try {
+//            Alert alert = wait.until(ExpectedConditions.alertIsPresent());
+//            if (alert.getText().contains("Ride created successfully")) {
+//                alert.accept();
+//                return true;
+//            } else {
+//                return false;
+//            }
+//        }catch (TimeoutException e){
+//            return false;
+//        }
+//    }
+//
+//    public void fillOrderFormAndOrderNoFreeDriver(){
+//        passengersInput.sendKeys(Keys.CONTROL+"a");
+//        passengersInput.sendKeys(Keys.DELETE);
+//        passengersInput.sendKeys("2");
+//        nowCheckBox.click();
+//        Select vehicleTypeSelect=new Select(vehicleType);
+//        vehicleTypeSelect.selectByValue("STANDARD");
+//        babySeatCB.click();
+//
+//        wait.until(ExpectedConditions.elementToBeClickable(submitBtn));
+//
+//        wait.until(ExpectedConditions.not(ExpectedConditions.textToBePresentInElement(submitBtn, "Calculating route...")));
+//
+//        submitBtn.click();
+//    }
+//
+//    public boolean isOrderedNoDriver(){
+//        try {
+//            Alert alert = wait.until(ExpectedConditions.alertIsPresent());
+//            if (alert.getText().contains("Failed to create ride. There is no free drivers.")) {
+//                alert.accept();
+//                return true;
+//            } else {
+//                return false;
+//            }
+//        }catch (TimeoutException e){
+//            return false;
+//        }
+//    }
+//
+//    public void fillOrderFormAndOrderScheduled() {
+//        passengersInput.sendKeys(Keys.CONTROL + "a");
+//        passengersInput.sendKeys(Keys.DELETE);
+//        passengersInput.sendKeys("2");
+//        LocalDateTime scheduleTime = LocalDateTime.now().plusHours(2);
+//        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm");
+//
+//        ((JavascriptExecutor) driver).executeScript("arguments[0].value='" + scheduleTime.format(formatter) + "';", datetime);
+//        ((JavascriptExecutor) driver).executeScript("arguments[0].dispatchEvent(new Event('input', {bubbles:true}));", datetime);
+//        ((JavascriptExecutor) driver).executeScript("arguments[0].dispatchEvent(new Event('change', {bubbles:true}));", datetime);
+//
+//        Select vehicleTypeSelect = new Select(vehicleType);
+//        vehicleTypeSelect.selectByValue("STANDARD");
+//        wait.until(ExpectedConditions.elementToBeClickable(submitBtn));
+//
+//        wait.until(ExpectedConditions.not(ExpectedConditions.textToBePresentInElement(submitBtn, "Calculating route...")));
+//
+//        submitBtn.click();
+//    }
+//
+//    public void fillOrderFormAndOrderScheduled_OverLapTime() {
+//        passengersInput.sendKeys(Keys.CONTROL + "a");
+//        passengersInput.sendKeys(Keys.DELETE);
+//        passengersInput.sendKeys("2");
+//        LocalDateTime scheduledTime=LocalDateTime.now().plusDays(1).withHour(17).withMinute(30);
+//        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm");
+//
+//        ((JavascriptExecutor) driver).executeScript("arguments[0].value='" + scheduledTime.format(formatter) + "';", datetime);
+//        ((JavascriptExecutor) driver).executeScript("arguments[0].dispatchEvent(new Event('input', {bubbles:true}));", datetime);
+//        ((JavascriptExecutor) driver).executeScript("arguments[0].dispatchEvent(new Event('change', {bubbles:true}));", datetime);
+//
+//        Select vehicleTypeSelect = new Select(vehicleType);
+//        vehicleTypeSelect.selectByValue("STANDARD");
+//        wait.until(ExpectedConditions.elementToBeClickable(submitBtn));
+//
+//        wait.until(ExpectedConditions.not(ExpectedConditions.textToBePresentInElement(submitBtn, "Calculating route...")));
+//
+//        submitBtn.click();
+//    }
+//
+//    public void fillOrderFormAndOrderScheduled_InvalidDateTime() {
+//        passengersInput.sendKeys(Keys.CONTROL + "a");
+//        passengersInput.sendKeys(Keys.DELETE);
+//        passengersInput.sendKeys("2");
+//        LocalDateTime scheduleTime = LocalDateTime.now().minusHours(2);
+//        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm");
+//
+//        ((JavascriptExecutor) driver).executeScript("arguments[0].value='" + scheduleTime.format(formatter) + "';", datetime);
+//        ((JavascriptExecutor) driver).executeScript("arguments[0].dispatchEvent(new Event('input', {bubbles:true}));", datetime);
+//        ((JavascriptExecutor) driver).executeScript("arguments[0].dispatchEvent(new Event('change', {bubbles:true}));", datetime);
+//
+//        Select vehicleTypeSelect = new Select(vehicleType);
+//        vehicleTypeSelect.selectByValue("STANDARD");
+//            wait.until(ExpectedConditions.elementToBeClickable(submitBtn));
+//            wait.until(ExpectedConditions.not(ExpectedConditions.textToBePresentInElement(submitBtn, "Calculating route...")));
+//            submitBtn.click();
+//
+//    }
+//
+//    public boolean invalidForm(){
+//        try {
+//            Alert alert = wait.until(ExpectedConditions.alertIsPresent());
+//            if (alert.getText().contains("Form is not valid!")) {
+//                alert.accept();
+//                return true;
+//            } else {
+//                return false;
+//            }
+//        }catch (TimeoutException e){
+//            return false;
+//        }
+//    }
+//
+//    public void fillOrderFormAndOrderScheduled_InvalidPassengerNumber() {
+//        passengersInput.sendKeys(Keys.CONTROL + "a");
+//        passengersInput.sendKeys(Keys.DELETE);
+//        passengersInput.sendKeys("0");
+//        LocalDateTime scheduleTime = LocalDateTime.now().plusDays(5);
+//        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm");
+//
+//        ((JavascriptExecutor) driver).executeScript("arguments[0].value='" + scheduleTime.format(formatter) + "';", datetime);
+//        ((JavascriptExecutor) driver).executeScript("arguments[0].dispatchEvent(new Event('input', {bubbles:true}));", datetime);
+//        ((JavascriptExecutor) driver).executeScript("arguments[0].dispatchEvent(new Event('change', {bubbles:true}));", datetime);
+//
+//        Select vehicleTypeSelect = new Select(vehicleType);
+//        vehicleTypeSelect.selectByValue("STANDARD");
+//        wait.until(ExpectedConditions.elementToBeClickable(submitBtn));
+//        wait.until(ExpectedConditions.not(ExpectedConditions.textToBePresentInElement(submitBtn, "Calculating route...")));
+//        submitBtn.click();
+//
+//    }
+//
+//    public void fillOrderFormAndOrderScheduled_InvalidVehicleType() {
+//        passengersInput.sendKeys(Keys.CONTROL + "a");
+//        passengersInput.sendKeys(Keys.DELETE);
+//        passengersInput.sendKeys("0");
+//        LocalDateTime scheduleTime = LocalDateTime.now().plusDays(5);
+//        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm");
+//
+//        ((JavascriptExecutor) driver).executeScript("arguments[0].value='" + scheduleTime.format(formatter) + "';", datetime);
+//        ((JavascriptExecutor) driver).executeScript("arguments[0].dispatchEvent(new Event('input', {bubbles:true}));", datetime);
+//        ((JavascriptExecutor) driver).executeScript("arguments[0].dispatchEvent(new Event('change', {bubbles:true}));", datetime);
+//
+//        wait.until(ExpectedConditions.elementToBeClickable(submitBtn));
+//        wait.until(ExpectedConditions.not(ExpectedConditions.textToBePresentInElement(submitBtn, "Calculating route...")));
+//        submitBtn.click();
+//
+//    }
+
+}

--- a/e2e-tests/src/test/java/pages/RideHistoryPage.java
+++ b/e2e-tests/src/test/java/pages/RideHistoryPage.java
@@ -1,0 +1,93 @@
+package pages;
+
+import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.sql.Time;
+import java.util.List;
+
+public class RideHistoryPage {
+    private WebDriver driver;
+    private WebDriverWait wait;
+
+
+    @FindBy(xpath = "//table//button[@title='Favorite']")
+    private List<WebElement> favoritesBtns;
+
+    @FindBy(id = "favoriteRouteName")
+    private WebElement favoriteRouteName;
+
+    @FindBy(id = "saveFavoriteRouteBtn")
+    private WebElement saveFavoriteRouteBtn;
+
+    @FindBy(id = "sidebarBtn")
+    private WebElement sidebar;
+
+    @FindBy(xpath = "//a[span[text()='Favourite Rides']]")
+    private WebElement favoriteRoutesLink;
+
+    @FindBy(tagName = "h2")
+    private WebElement title;
+
+
+    public RideHistoryPage(WebDriver driver){
+        this.driver=driver;
+        wait= new WebDriverWait(driver, 3);
+        PageFactory.initElements(driver,this);
+    }
+    public boolean rideHistoryLoaded()
+    {
+        try{
+            wait.until(ExpectedConditions.textToBePresentInElement(title,"Ride history"));
+            return true;
+        }catch (TimeoutException e){
+            return false;
+        }
+    }
+    public boolean addRouteToFavorites(){
+        try {
+            wait.until(ExpectedConditions.visibilityOfAllElements(favoritesBtns));
+
+            WebElement firstFavBtn = favoritesBtns.get(0);
+            if(firstFavBtn.getAttribute("class").contains("favorited")){
+                wait.until(ExpectedConditions.elementToBeClickable(firstFavBtn)).click(); // da se izbaci iz omiljenih prvo
+                wait.until(ExpectedConditions.elementToBeClickable(firstFavBtn)).click();
+            }else{
+                wait.until(ExpectedConditions.elementToBeClickable(firstFavBtn)).click();
+            }
+            wait.until(ExpectedConditions.visibilityOf(favoriteRouteName));
+            favoriteRouteName.sendKeys("Home->Gym");
+
+            wait.until(ExpectedConditions.elementToBeClickable(saveFavoriteRouteBtn)).click();
+            wait.until(ExpectedConditions.attributeContains(firstFavBtn, "class", "favorited"));
+        }
+         catch (TimeoutException e){
+                return false;
+            }
+        return true;
+    }
+
+    public void goToFavoriteRoutes(){
+        sidebar.click();
+        wait.until(ExpectedConditions.elementToBeClickable(favoriteRoutesLink)).click();
+    }
+
+    public boolean removeFromFavorites(){
+        try {
+            wait.until(ExpectedConditions.visibilityOfAllElements(favoritesBtns));
+
+            WebElement firstFavBtn = favoritesBtns.get(0);
+            wait.until(ExpectedConditions.elementToBeClickable(firstFavBtn)).click();
+            wait.until(ExpectedConditions.not(ExpectedConditions.attributeContains(firstFavBtn,"class","favorited")));
+        }
+        catch (TimeoutException e){
+            return false;
+        }
+        return true;
+    }
+}

--- a/e2e-tests/src/test/java/tests/FavoriteRoutesOrderTest.java
+++ b/e2e-tests/src/test/java/tests/FavoriteRoutesOrderTest.java
@@ -1,0 +1,306 @@
+package tests;
+
+import org.junit.Assert;
+import org.testng.annotations.Test;
+import pages.FavoriteRoutesPage;
+import pages.PassengerHomePage;
+import pages.RideHistoryPage;
+
+public class FavoriteRoutesOrderTest extends TestBase{
+
+    @Test
+    private void addToFavoriteRoutes(){
+        loginAsPassenger();
+        PassengerHomePage passengerHomePage=new PassengerHomePage(driver);
+
+        Assert.assertTrue(passengerHomePage.isLoaded());
+
+        passengerHomePage.goToPassengerHistory();
+
+        RideHistoryPage rideHistoryPage= new RideHistoryPage(driver);
+
+        Assert.assertTrue(rideHistoryPage.rideHistoryLoaded());
+        Assert.assertTrue(rideHistoryPage.addRouteToFavorites());
+        rideHistoryPage.goToFavoriteRoutes();
+
+        FavoriteRoutesPage favoriteRoutesPage= new FavoriteRoutesPage(driver);
+        Assert.assertTrue(favoriteRoutesPage.favoriteRoutesPageLoaded());
+        Assert.assertTrue(favoriteRoutesPage.favoriteRouteAdded());
+    }
+
+    @Test
+    private void removeFromFavoritesHistoryPage(){
+        addToFavoriteRoutes();
+        PassengerHomePage passengerHomePage=new PassengerHomePage(driver);
+
+        Assert.assertTrue(passengerHomePage.isLoaded());
+
+        passengerHomePage.goToPassengerHistory();
+
+        RideHistoryPage rideHistoryPage= new RideHistoryPage(driver);
+
+        Assert.assertTrue(rideHistoryPage.rideHistoryLoaded());
+        Assert.assertTrue(rideHistoryPage.addRouteToFavorites());
+
+        Assert.assertTrue(rideHistoryPage.removeFromFavorites());
+    }
+    @Test
+    private void removeFromFavorites_FavoritesPage(){
+        addToFavoriteRoutes();
+        PassengerHomePage passengerHomePage=new PassengerHomePage(driver);
+
+        Assert.assertTrue(passengerHomePage.isLoaded());
+
+        passengerHomePage.goToFavoritesPage();
+        FavoriteRoutesPage favoriteRoutesPage= new FavoriteRoutesPage(driver);
+        Assert.assertTrue(favoriteRoutesPage.favoriteRoutesPageLoaded());
+
+        Assert.assertTrue(favoriteRoutesPage.removeFavoriteRoute());
+    }
+
+    @Test
+    private void addToFavoritesAndOrder(){
+        loginAsPassenger();
+        PassengerHomePage passengerHomePage=new PassengerHomePage(driver);
+
+        Assert.assertTrue(passengerHomePage.isLoaded());
+
+        passengerHomePage.goToPassengerHistory();
+
+        RideHistoryPage rideHistoryPage= new RideHistoryPage(driver);
+
+        Assert.assertTrue(rideHistoryPage.rideHistoryLoaded());
+        Assert.assertTrue(rideHistoryPage.addRouteToFavorites());
+
+        rideHistoryPage.goToFavoriteRoutes();
+
+        FavoriteRoutesPage favoriteRoutesPage= new FavoriteRoutesPage(driver);
+        Assert.assertTrue(favoriteRoutesPage.favoriteRoutesPageLoaded());
+        Assert.assertTrue(favoriteRoutesPage.favoriteRouteAdded());
+        favoriteRoutesPage.orderRouteAgain();
+
+        Assert.assertTrue(passengerHomePage.isLoaded());
+
+        Assert.assertTrue(passengerHomePage.areAllCoordinatesFilled());
+    }
+
+/////////////////////////////////// ne znam da l je trebalo al eto ima visak ako nista //////////////////////////////////////////////
+
+
+//    @Test
+//    private void favoriteRideOrder_Now_AddFromHistory(){
+//        loginAsPassenger();
+//        PassengerHomePage passengerHomePage=new PassengerHomePage(driver);
+//
+//        Assert.assertTrue(passengerHomePage.isLoaded());
+//
+//        passengerHomePage.goToPassengerHistory();
+//
+//        RideHistoryPage rideHistoryPage= new RideHistoryPage(driver);
+//
+//        Assert.assertTrue(rideHistoryPage.rideHistoryLoaded());
+//        Assert.assertTrue(rideHistoryPage.addRouteToFavorites());
+//
+//        rideHistoryPage.goToFavoriteRoutes();
+//
+//        FavoriteRoutesPage favoriteRoutesPage= new FavoriteRoutesPage(driver);
+//        Assert.assertTrue(favoriteRoutesPage.favoriteRoutesPageLoaded());
+//        Assert.assertTrue(favoriteRoutesPage.favoriteRouteAdded());
+//        favoriteRoutesPage.orderRouteAgain();
+//
+//        Assert.assertTrue(passengerHomePage.isLoaded());
+//
+//        passengerHomePage.fillOrderFormAndOrder();
+//        Assert.assertTrue(passengerHomePage.isOrdered());
+//
+//    }
+//
+//
+//    @Test
+//    private void favoriteRideOrder_Now_AddFromHistory_NoFreeDrivers(){
+//        loginAsPassenger();
+//        PassengerHomePage passengerHomePage=new PassengerHomePage(driver);
+//
+//        Assert.assertTrue(passengerHomePage.isLoaded());
+//
+//        passengerHomePage.goToPassengerHistory();
+//
+//        RideHistoryPage rideHistoryPage= new RideHistoryPage(driver);
+//
+//        Assert.assertTrue(rideHistoryPage.rideHistoryLoaded());
+//        Assert.assertTrue(rideHistoryPage.addRouteToFavorites());
+//
+//        rideHistoryPage.goToFavoriteRoutes();
+//
+//        FavoriteRoutesPage favoriteRoutesPage= new FavoriteRoutesPage(driver);
+//        Assert.assertTrue(favoriteRoutesPage.favoriteRoutesPageLoaded());
+//        Assert.assertTrue(favoriteRoutesPage.favoriteRouteAdded());
+//        favoriteRoutesPage.orderRouteAgain();
+//
+//        Assert.assertTrue(passengerHomePage.isLoaded());
+//
+//        passengerHomePage.fillOrderFormAndOrderNoFreeDriver();
+//        Assert.assertTrue(passengerHomePage.isOrderedNoDriver());
+//    }
+//
+//    @Test
+//    private void favoriteRideOrder_Scheduled_AddFromHistory(){
+//        loginAsPassenger();
+//        PassengerHomePage passengerHomePage=new PassengerHomePage(driver);
+//
+//        Assert.assertTrue(passengerHomePage.isLoaded());
+//
+//        passengerHomePage.goToPassengerHistory();
+//
+//        RideHistoryPage rideHistoryPage= new RideHistoryPage(driver);
+//
+//        Assert.assertTrue(rideHistoryPage.rideHistoryLoaded());
+//        Assert.assertTrue(rideHistoryPage.addRouteToFavorites());
+//
+//        rideHistoryPage.goToFavoriteRoutes();
+//
+//        FavoriteRoutesPage favoriteRoutesPage= new FavoriteRoutesPage(driver);
+//        Assert.assertTrue(favoriteRoutesPage.favoriteRoutesPageLoaded());
+//        Assert.assertTrue(favoriteRoutesPage.favoriteRouteAdded());
+//        favoriteRoutesPage.orderRouteAgain();
+//
+//        Assert.assertTrue(passengerHomePage.isLoaded());
+//
+//        passengerHomePage.fillOrderFormAndOrderScheduled();
+//        Assert.assertTrue(passengerHomePage.isOrdered());
+//
+//    }
+//
+//    @Test
+//    private void favoriteRideOrder_Scheduled_AddFromHistory_OverLapInScheduledTime(){
+//        loginAsPassenger();
+//        PassengerHomePage passengerHomePage=new PassengerHomePage(driver);
+//
+//        Assert.assertTrue(passengerHomePage.isLoaded());
+//
+//        passengerHomePage.goToPassengerHistory();
+//
+//        RideHistoryPage rideHistoryPage= new RideHistoryPage(driver);
+//
+//        Assert.assertTrue(rideHistoryPage.rideHistoryLoaded());
+//        Assert.assertTrue(rideHistoryPage.addRouteToFavorites());
+//
+//        rideHistoryPage.goToFavoriteRoutes();
+//
+//        FavoriteRoutesPage favoriteRoutesPage= new FavoriteRoutesPage(driver);
+//        Assert.assertTrue(favoriteRoutesPage.favoriteRoutesPageLoaded());
+//        Assert.assertTrue(favoriteRoutesPage.favoriteRouteAdded());
+//        favoriteRoutesPage.orderRouteAgain();
+//
+//        Assert.assertTrue(passengerHomePage.isLoaded());
+//
+//        passengerHomePage.fillOrderFormAndOrderScheduled_OverLapTime();
+//        Assert.assertTrue(passengerHomePage.isOrdered());
+////drugi put porucuje isto
+//
+//        PassengerHomePage passengerHomePage2=new PassengerHomePage(driver);
+//
+//        Assert.assertTrue(passengerHomePage2.isLoaded());
+//
+//        passengerHomePage2.goToPassengerHistory();
+//
+//        RideHistoryPage rideHistoryPage2= new RideHistoryPage(driver);
+//
+//        Assert.assertTrue(rideHistoryPage2.rideHistoryLoaded());
+//        Assert.assertTrue(rideHistoryPage2.addRouteToFavorites());
+//
+//        rideHistoryPage2.goToFavoriteRoutes();
+//
+//        FavoriteRoutesPage favoriteRoutesPage2= new FavoriteRoutesPage(driver);
+//        Assert.assertTrue(favoriteRoutesPage2.favoriteRoutesPageLoaded());
+//        Assert.assertTrue(favoriteRoutesPage2.favoriteRouteAdded());
+//        favoriteRoutesPage2.orderRouteAgain();
+//
+//        Assert.assertTrue(passengerHomePage2.isLoaded());
+//
+//        passengerHomePage2.fillOrderFormAndOrderScheduled_OverLapTime();
+//        Assert.assertTrue(passengerHomePage2.isOrderedNoDriver());
+//
+//    }
+//
+//    @Test
+//    private void favoriteRideOrder_InvalidDate(){
+//        loginAsPassenger();
+//        PassengerHomePage passengerHomePage=new PassengerHomePage(driver);
+//
+//        Assert.assertTrue(passengerHomePage.isLoaded());
+//
+//        passengerHomePage.goToPassengerHistory();
+//
+//        RideHistoryPage rideHistoryPage= new RideHistoryPage(driver);
+//
+//        Assert.assertTrue(rideHistoryPage.rideHistoryLoaded());
+//        Assert.assertTrue(rideHistoryPage.addRouteToFavorites());
+//
+//        rideHistoryPage.goToFavoriteRoutes();
+//
+//        FavoriteRoutesPage favoriteRoutesPage= new FavoriteRoutesPage(driver);
+//        Assert.assertTrue(favoriteRoutesPage.favoriteRoutesPageLoaded());
+//        Assert.assertTrue(favoriteRoutesPage.favoriteRouteAdded());
+//        favoriteRoutesPage.orderRouteAgain();
+//
+//        Assert.assertTrue(passengerHomePage.isLoaded());
+//
+//        passengerHomePage.fillOrderFormAndOrderScheduled_InvalidDateTime();
+//        Assert.assertTrue(passengerHomePage.invalidForm());
+//    }
+//
+//    @Test
+//    private void favoriteRideOrder_InvalidPassengerNumber(){
+//        loginAsPassenger();
+//        PassengerHomePage passengerHomePage=new PassengerHomePage(driver);
+//
+//        Assert.assertTrue(passengerHomePage.isLoaded());
+//
+//        passengerHomePage.goToPassengerHistory();
+//
+//        RideHistoryPage rideHistoryPage= new RideHistoryPage(driver);
+//
+//        Assert.assertTrue(rideHistoryPage.rideHistoryLoaded());
+//        Assert.assertTrue(rideHistoryPage.addRouteToFavorites());
+//
+//        rideHistoryPage.goToFavoriteRoutes();
+//
+//        FavoriteRoutesPage favoriteRoutesPage= new FavoriteRoutesPage(driver);
+//        Assert.assertTrue(favoriteRoutesPage.favoriteRoutesPageLoaded());
+//        Assert.assertTrue(favoriteRoutesPage.favoriteRouteAdded());
+//        favoriteRoutesPage.orderRouteAgain();
+//
+//        Assert.assertTrue(passengerHomePage.isLoaded());
+//
+//        passengerHomePage.fillOrderFormAndOrderScheduled_InvalidPassengerNumber();
+//        Assert.assertTrue(passengerHomePage.invalidForm());
+//    }
+//
+//    @Test
+//    private void favoriteRideOrder_InvalidVehicleType(){
+//        loginAsPassenger();
+//        PassengerHomePage passengerHomePage=new PassengerHomePage(driver);
+//
+//        Assert.assertTrue(passengerHomePage.isLoaded());
+//
+//        passengerHomePage.goToPassengerHistory();
+//
+//        RideHistoryPage rideHistoryPage= new RideHistoryPage(driver);
+//
+//        Assert.assertTrue(rideHistoryPage.rideHistoryLoaded());
+//        Assert.assertTrue(rideHistoryPage.addRouteToFavorites());
+//
+//        rideHistoryPage.goToFavoriteRoutes();
+//
+//        FavoriteRoutesPage favoriteRoutesPage= new FavoriteRoutesPage(driver);
+//        Assert.assertTrue(favoriteRoutesPage.favoriteRoutesPageLoaded());
+//        Assert.assertTrue(favoriteRoutesPage.favoriteRouteAdded());
+//        favoriteRoutesPage.orderRouteAgain();
+//
+//        Assert.assertTrue(passengerHomePage.isLoaded());
+//
+//        passengerHomePage.fillOrderFormAndOrderScheduled_InvalidVehicleType();
+//        Assert.assertTrue(passengerHomePage.invalidForm());
+//    }
+}

--- a/frontend/FleetForge/src/app/navigation/navbar/navbar.component.html
+++ b/frontend/FleetForge/src/app/navigation/navbar/navbar.component.html
@@ -1,7 +1,7 @@
 <nav class="navbar">
   <div class="navbar-left">
     <button type="button" class="logo-btn" (click)="onLogoClick()" [disabled]="!(isAuthenticated$ | async)"
-      aria-label="Toggle sidebar" [attr.aria-disabled]="!(isAuthenticated$ | async)">
+      aria-label="Toggle sidebar" [attr.aria-disabled]="!(isAuthenticated$ | async)" id="sidebarBtn">
       <img class="brand__logo" src="logo.png" alt="FleetForge logo" />
     </button>
 

--- a/frontend/FleetForge/src/app/passenger/passenger-favorite-routes/passenger-favorite-routes.component.html
+++ b/frontend/FleetForge/src/app/passenger/passenger-favorite-routes/passenger-favorite-routes.component.html
@@ -6,7 +6,7 @@
     <div class="rides-section">
 
         <div class="table-container">
-            <table class="rides-table">
+            <table class="rides-table" id="favoriteRoutesTable">
                 <thead>
                     <tr>
                         <th class="col-fixed">Name</th>

--- a/frontend/FleetForge/src/app/passenger/passenger-history/passenger-history.component.html
+++ b/frontend/FleetForge/src/app/passenger/passenger-history/passenger-history.component.html
@@ -254,7 +254,7 @@
 			<div class="favorite-modal__actions">
 				<button type="button" class="modal-btn ghost" (click)="closeFavoriteModal()">Cancel</button>
 				<button type="button" class="modal-btn primary" [disabled]="!favoriteRouteName.trim()"
-					(click)="saveFavoriteRoute()">
+					(click)="saveFavoriteRoute()" id="saveFavoriteRouteBtn">
 					Save
 				</button>
 			</div>

--- a/frontend/FleetForge/src/app/passenger/passenger-home/passenger-home.component.html
+++ b/frontend/FleetForge/src/app/passenger/passenger-home/passenger-home.component.html
@@ -152,7 +152,7 @@
           </div>
         </div>
 
-        <button class="btn btn-order" type="submit" [disabled]="rideService.isRideActive">Order Ride</button>
+        <button class="btn btn-order" type="submit" [disabled]="rideService.isRideActive || isRouteLoading">{{ isRouteLoading ? 'Calculating route...' : 'Order Ride' }}</button>
 
       </form>
 

--- a/frontend/FleetForge/src/app/passenger/passenger-home/passenger-home.component.ts
+++ b/frontend/FleetForge/src/app/passenger/passenger-home/passenger-home.component.ts
@@ -55,6 +55,7 @@ export class PassengerHomeComponent implements OnDestroy {
   private pickupSearchSubject = new Subject<string>();
   private dropoffSearchSubject = new Subject<string>();
   private waypointSearchSubjects = new Map<number, Subject<string>>();
+  isRouteLoading: boolean = false;
   
   private subscriptions: Subscription[] = [];
   estimatedDistance: number = 0;
@@ -398,6 +399,8 @@ vehicles: VehicleLocationDTO[] = [];
   ngAfterViewInit(): void {
     const data = history.state.favoriteRoute;
     if (data) {
+      this.isRouteLoading = true;
+      this.cdr.detectChanges();
       this.rideForm.get('pickup')?.setValue(data.startAddress);
       this.rideForm.get('dropoff')?.setValue(data.endAddress);
 
@@ -457,20 +460,6 @@ vehicles: VehicleLocationDTO[] = [];
   scrollToBookRide(): void {
     document.getElementById('bookRide')?.scrollIntoView();
   }
-
-  // loadVehicles(): void {
-  //   this.vehicleService.getActiveVehicles().subscribe({
-  //     next: (vehicles) => {
-  //       this.vehicles = [...vehicles]; 
-  //       this.cdr.detectChanges(); 
-  //       console.log('Loaded vehicles:', this.vehicles);
-  //       console.log('vehicles property after assignment:', this.vehicles);
-  //     },
-  //     error: (error) => {
-  //       console.error('Error loading vehicles:', error);
-  //     }
-  //   });
-  // }
   addPassengerInput(): void {
   this.passengerArray.push(
       new FormControl('', { validators: [Validators.required, Validators.email], nonNullable: true })
@@ -521,6 +510,8 @@ this.waypointArray.controls.forEach(control => {
   const dropoffMarker = this.mapComponent['locationMarkers'].get(endingPoint.value);
   
   if (pickupMarker && dropoffMarker) {
+    this.isRouteLoading = true;
+    this.cdr.detectChanges();
     const pickupLatLng = pickupMarker.getLatLng();
     const dropoffLatLng = dropoffMarker.getLatLng();
     this.mapComponent.updateRoute(
@@ -529,6 +520,8 @@ this.waypointArray.controls.forEach(control => {
       waypoints
     );
   } else {
+    this.isRouteLoading = false;
+    this.cdr.detectChanges();
     this.mapComponent.clearRoute();
   }
 }
@@ -538,6 +531,8 @@ this.waypointArray.controls.forEach(control => {
     this.estimatedDistance = summary.distanceKm;
     this.estimatedDuration = summary.durationMin;
     this.estimatedCost = summary.cost;
+    this.isRouteLoading = false;
+    this.cdr.detectChanges();
     console.log('Route summary received in component:', summary);
   }
   private refactorIdsWaypoints(): void {


### PR DESCRIPTION
## Description

Added E2E Selenium tests for the **Favorite Routes - Ride Order** functionality (2.4.3).

## Changes

### Tests added
- `FavoriteRoutesPage` - Page object with locators and helper methods for the Favorite Routes page
- `PassengerHomePage` - Page object with locators and helper methods for the Passenger Home page
- `RideHistoryPage` - Page object with locators and helper methods for the Ride History page
- `FavoriteRoutesOrderTest` - Test suite covering happy path and edge cases

### Test cases covered
- ✅ Happy path - add route to favorites from history and order it
- ✅ Order favorite route with waypoints - verify all fields are pre-filled correctly
- ✅ Scheduled ride order from favorite routes
- ✅ No free drivers available
- ✅ Scheduled ride with overlapping time
- ✅ Invalid form - past datetime
- ✅ Invalid form - passenger number
- ✅ Invalid form - vehicle type
- ✅ Remove route from favorites

### Frontend/Backend fixes
- Minor frontend fixes to improve testability (IDs, labels, loading state)
- DataLoader update with test data for edge cases

## Closes #259 