### PR TITLE
feat(test): Add e2e for rate ride functioanlity

### DIFF
--- a/backend/FleetForge/src/main/java/com/team18/FleetForge/config/DataLoader.java
+++ b/backend/FleetForge/src/main/java/com/team18/FleetForge/config/DataLoader.java
@@ -398,6 +398,18 @@ public class DataLoader implements CommandLineRunner {
         ride20.setLinkedPassengers(new ArrayList<>(List.of(passenger1, passenger2)));
         rideRepository.save(ride20);
 
+        Ride ride21 = createRide(
+                driver1, passenger1,
+                new GeoPoint(45.2580, 19.8620), "Sajam, Novi Sad",
+                new GeoPoint(45.2470, 19.8250), "Novo Naselje, Novi Sad",
+                LocalDateTime.now().minusDays(4).minusHours(12).withMinute(0),
+                LocalDateTime.now().minusDays(4).minusHours(11).withMinute(20),
+                10.5, 40.0, 1550.0,
+                RideStatus.COMPLETED, false, null, null
+        );
+        rideRepository.save(ride21);
+
+
         InconsistencyReport report = InconsistencyReport.builder()
                 .ride(ride20)
                 .reporter(passenger2)

--- a/e2e-tests/src/test/java/pages/PassengerRideHistoryPage.java
+++ b/e2e-tests/src/test/java/pages/PassengerRideHistoryPage.java
@@ -1,0 +1,130 @@
+package pages;
+
+import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import tests.TestBase;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+public class PassengerRideHistoryPage extends TestBase {
+
+    private WebDriver driver;
+    private WebDriverWait wait;
+
+    @FindBy(tagName = "h2")
+    private WebElement title;
+
+    @FindBy(xpath= "//button[@class='action-btn rate'][1]")
+    private WebElement rateButton;
+
+    @FindBy(xpath="//button[@aria-label='Rate driver 4 star']")
+    private WebElement driverRatingButton;
+
+    @FindBy(xpath="//button[@aria-label='Rate vehicle 3 star']")
+    private WebElement vehicleRatingButton;
+
+    @FindBy(xpath="//textarea[contains(@class, 'comment-input')]")
+    private WebElement commentSection;
+
+    @FindBy(xpath="//h3[text()='Rate your ride']")
+    private WebElement ratingModal;
+
+    @FindBy(xpath="//button[normalize-space(text())='Submit']")
+    private WebElement submitBtn;
+
+    @FindBy(xpath="//tbody/tr[1]//div[@class='stars']")
+    private WebElement starsField;
+
+    @FindBy(xpath="//tbody/tr[2]//div[@class='stars']")
+    private WebElement previousStarsField;
+
+    @FindBy(xpath="//tbody/tr[3]//div[@class='rating-expired']")
+    private WebElement ratingExpiredField;
+
+
+
+
+    public PassengerRideHistoryPage(WebDriver driver){
+        this.driver=driver;
+        wait= new WebDriverWait(driver, 10);
+        PageFactory.initElements(driver,this);
+    }
+
+    public boolean rideHistoryLoaded()
+    {
+        try{
+            wait.until(ExpectedConditions.textToBePresentInElement(title,"Ride history"));
+            return true;
+        }catch (TimeoutException e){
+            return false;
+        }
+    }
+
+    public void clickRateButton() {
+        wait.until(ExpectedConditions.elementToBeClickable(rateButton));
+        rateButton.click();
+    }
+
+    public void rateDriver() {
+        wait.until(ExpectedConditions.elementToBeClickable(driverRatingButton));
+        driverRatingButton.click();
+    }
+
+    public void rateVehicle() {
+        wait.until(ExpectedConditions.elementToBeClickable(vehicleRatingButton));
+        vehicleRatingButton.click();
+    }
+
+    public void enterComment(String comment) {
+        wait.until(ExpectedConditions.elementToBeClickable(commentSection));
+        commentSection.sendKeys(comment);
+    }
+
+    public void submitRating() {
+        wait.until(ExpectedConditions.elementToBeClickable(submitBtn));
+        submitBtn.click();
+    }
+
+    public boolean isRatingModalOpen() {
+        try {
+            wait.until(ExpectedConditions.visibilityOf(ratingModal));
+            return true;
+        } catch (TimeoutException e) {
+            return false;
+        }
+    }
+
+    public boolean isStarFieldDisplayed() {
+        try {
+            wait.until(ExpectedConditions.visibilityOf(starsField));
+            return true;
+        } catch (TimeoutException e) {
+            return false;
+        }
+    }
+
+    public boolean isSubmitEnabled() {
+        return submitBtn.isEnabled();
+    }
+
+    public boolean isPreviousRideRated() {
+        try {
+            wait.until(ExpectedConditions.visibilityOf(previousStarsField));
+            return true;
+        } catch (TimeoutException e) {
+            return false;
+        }
+    }
+
+    public boolean isRatingExpired() {
+        try {
+            wait.until(ExpectedConditions.visibilityOf(ratingExpiredField));
+            return true;
+        } catch (TimeoutException e) {
+            return false;
+        }
+    }
+}

--- a/e2e-tests/src/test/java/tests/RateRideTest.java
+++ b/e2e-tests/src/test/java/tests/RateRideTest.java
@@ -1,0 +1,62 @@
+package tests;
+
+import org.junit.Assert;
+import org.testng.annotations.Test;
+import pages.PassengerHomePage;
+import pages.PassengerRideHistoryPage;
+
+public class RateRideTest extends TestBase {
+
+    @Test
+    public void rateRide(){
+        loginAsPassenger();
+        PassengerHomePage passengerHomePage = new PassengerHomePage(driver);
+        Assert.assertTrue(passengerHomePage.isLoaded());
+
+        passengerHomePage.goToPassengerHistory();
+
+        PassengerRideHistoryPage passengerRideHistory = new PassengerRideHistoryPage(driver);
+        Assert.assertTrue(passengerRideHistory.rideHistoryLoaded());
+
+        passengerRideHistory.clickRateButton();
+        Assert.assertTrue(passengerRideHistory.isRatingModalOpen());
+
+        passengerRideHistory.rateDriver();
+        passengerRideHistory.rateVehicle();
+        passengerRideHistory.enterComment("Fine ride");
+        Assert.assertTrue(passengerRideHistory.isSubmitEnabled());
+
+
+        passengerRideHistory.submitRating();
+        Assert.assertTrue(passengerRideHistory.isStarFieldDisplayed());
+
+    }
+
+    @Test
+    public void rideAlreadyRated() {
+        loginAsPassenger();
+        PassengerHomePage passengerHomePage = new PassengerHomePage(driver);
+        Assert.assertTrue(passengerHomePage.isLoaded());
+
+        passengerHomePage.goToPassengerHistory();
+
+        PassengerRideHistoryPage passengerRideHistory = new PassengerRideHistoryPage(driver);
+        Assert.assertTrue(passengerRideHistory.rideHistoryLoaded());
+
+        Assert.assertTrue(passengerRideHistory.isPreviousRideRated());
+    }
+
+    @Test
+    public void ratingExpired() {
+        loginAsPassenger();
+        PassengerHomePage passengerHomePage = new PassengerHomePage(driver);
+        Assert.assertTrue(passengerHomePage.isLoaded());
+
+        passengerHomePage.goToPassengerHistory();
+
+        PassengerRideHistoryPage passengerRideHistory = new PassengerRideHistoryPage(driver);
+        Assert.assertTrue(passengerRideHistory.rideHistoryLoaded());
+
+        Assert.assertTrue(passengerRideHistory.isRatingExpired());
+    }
+}

--- a/frontend/FleetForge/src/app/passenger/passenger-history/passenger-history.component.html
+++ b/frontend/FleetForge/src/app/passenger/passenger-history/passenger-history.component.html
@@ -78,7 +78,7 @@
 							<td class="action-cell">
 								<ng-container [ngSwitch]="getRatingState(ride)">
 									<div *ngSwitchCase="'rated'" class="stars">
-										<span *ngFor="let filled of getStarArray(ride.averageReview || 0)" class="star"
+										<span *ngFor="let filled of getStarArray(ride.driverRating || 0)" class="star"
 											[class.filled]="filled">
 											★
 										</span>

--- a/frontend/FleetForge/src/app/passenger/passenger-history/passenger-history.component.ts
+++ b/frontend/FleetForge/src/app/passenger/passenger-history/passenger-history.component.ts
@@ -1,4 +1,4 @@
-import { Component, signal, WritableSignal } from '@angular/core';
+import { Component, signal, WritableSignal, ChangeDetectorRef } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { PassengerHistory, PassengerRideDetailsDto } from '../service/passenger-history/passenger-history';
@@ -20,7 +20,6 @@ interface Ride {
   status: RideStatus;
   driverRating?: number;
   vehicleRating?: number;
-  averageReview?: number;
   ratingComment?: string;
 }
 
@@ -43,7 +42,8 @@ export class PassengerHistoryComponent {
     private passengerHistory: PassengerHistory,
     private passengerFavorite: PassengerFavorite,
     private rideReviewService: RideReviewService,
-    private router: Router
+    private router: Router,
+    private cdr: ChangeDetectorRef
   ) {}
   isRatingModalOpen = false;
   selectedRide: Ride | null = null;
@@ -304,12 +304,17 @@ export class PassengerHistoryComponent {
       })
       .subscribe({
         next: (response) => {
-          this.selectedRide!.driverRating = response.driverRating;
-          this.selectedRide!.vehicleRating = response.vehicleRating;
-          this.selectedRide!.ratingComment = response.comment;
+          if (this.selectedRide) {
+            this.selectedRide.driverRating = response.driverRating;
+            this.selectedRide.vehicleRating = response.vehicleRating;
+            this.selectedRide.ratingComment = response.comment;
+          }
 
           this.isRatingLoading = false;
-          this.closeRatingModal();
+          this.isRatingModalOpen = false;
+          this.selectedRide = null;
+          this.ratingForm = { driverRating: 0, vehicleRating: 0, comment: '' };
+          this.cdr.markForCheck();
         },
         error: (err) => {
           console.error('Failed to submit rating:', err);


### PR DESCRIPTION
**Target Branch:** `develop`  
**Source Branch:** `test/rate-ride`

This pull request introduces end-to-end tests for the passenger ride rating functionality. It covers the complete rating workflow, including modal interactions, form submission, and various rating states.

### Changes:
- **Page Object**: Implemented `PassengerRideHistoryPage` with locators for rating modal, star buttons, comment section, and submit button.
- **Rating Flow Test**: Added `rateRide()` test covering the complete flow: opening rating modal, selecting driver/vehicle ratings, entering comments, and verifying successful submission.
- **Rating States Tests**: Implemented tests for `rideAlreadyRated()` and `ratingExpired()` to validate different rating state displays.
- **Validation**: Added assertions for modal visibility, submit button state, and star field display after successful rating.

### Closes
- Closes #265 