### PR TITLE
Feature/blocking users mobile

### DIFF
--- a/frontend/FleetForge/src/app/profiles/driver-profile/driver-profile.component.ts
+++ b/frontend/FleetForge/src/app/profiles/driver-profile/driver-profile.component.ts
@@ -42,10 +42,6 @@ closeBlockedDialog(): void {
 }
 
 editDriver(): void {
-  if (this.isBlocked()) {
-    return;
-  }
-
   const file = this.formData.get('file') as File | null;
   const fileExtension = file ? file.name.substring(file.name.lastIndexOf('.')) : '';
   console.log("img: " + this.driverEmail + fileExtension);
@@ -60,10 +56,6 @@ editDriver(): void {
   });
 }
 editVehicle(): void {
-  if (this.isBlocked()) {
-    return;
-  }
-
   this.driverService.createVehicleChangeRequest({
     newModel: this.editVehicleInfo.value.model ?? '',
     newType: (this.editVehicleInfo.value.type ?? '') as VehicleType,
@@ -79,10 +71,6 @@ editVehicle(): void {
 @ViewChild('fileInput') fileInput!: ElementRef<HTMLInputElement>;
   imageUrl: string = 'blank_profile.webp';
   openFilePicker(): void {
-    if (this.isBlocked()) {
-      return;
-    }
-
     this.fileInput.nativeElement.click();
   }
   onFileSelected(event: Event): void {

--- a/mobile/app/src/main/java/com/ognjen/fleetforge/activities/MainActivity.java
+++ b/mobile/app/src/main/java/com/ognjen/fleetforge/activities/MainActivity.java
@@ -10,6 +10,7 @@ import androidx.fragment.app.Fragment;
 import com.ognjen.fleetforge.fragments.admin.AdminProfile;
 import com.ognjen.fleetforge.fragments.admin.DriverChangesFragment;
 import com.ognjen.fleetforge.activities.auth.LoginActivity;
+import com.ognjen.fleetforge.fragments.admin.UsersList;
 import com.ognjen.fleetforge.fragments.driver.CurrentRideDriver;
 import com.ognjen.fleetforge.fragments.admin.RegisterDriver;
 import com.ognjen.fleetforge.fragments.driver.DriverHistoryFragment;
@@ -113,7 +114,7 @@ public class MainActivity extends AppCompatActivity {
         } else if (itemId == R.id.nav_register_driver) {
             return new RegisterDriver();
         } else if (itemId == R.id.nav_block_users) {
-            return PlaceholderFragment.newInstance("Block Users");
+            return new UsersList();
         } else if (itemId == R.id.nav_profile_changes) {
             return new DriverChangesFragment();
         }else if(itemId==R.id.nav_favorites){

--- a/mobile/app/src/main/java/com/ognjen/fleetforge/adapters/UsersListAdatper.java
+++ b/mobile/app/src/main/java/com/ognjen/fleetforge/adapters/UsersListAdatper.java
@@ -1,0 +1,93 @@
+package com.ognjen.fleetforge.adapters;
+
+import android.content.Context;
+import android.content.res.ColorStateList;
+import android.graphics.Color;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
+
+import com.ognjen.fleetforge.R;
+import com.ognjen.fleetforge.dtos.user.UserInformationDTO;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
+public class UsersListAdatper extends ArrayAdapter<UserInformationDTO> {
+
+    private ArrayList<UserInformationDTO> users;
+    private Set<Long> blockedUsersIds = new HashSet<>();
+    public void setBlockedUsersIds(Set<Long> blockedUsersIds) {
+        this.blockedUsersIds = blockedUsersIds;
+        notifyDataSetChanged();
+    }
+    public UsersListAdatper(Context context, ArrayList<UserInformationDTO> resource) {
+        super(context, R.layout.user_info_card);
+        this.users=resource;
+    }
+
+    private UsersListAdatper.OnActionListener listener;
+    public interface OnActionListener {
+        void onBlock(UserInformationDTO request, int position);
+    }
+    public void setOnActionListener(UsersListAdatper.OnActionListener listener) {
+        this.listener = listener;
+    }
+    @Override
+    public int getCount(){
+        return users.size();
+    }
+
+    @Nullable
+    @Override
+    public UserInformationDTO getItem(int position){
+        return users.get(position);
+    }
+
+    @Override
+    public long getItemId(int position){
+        return position;
+    }
+
+    @NonNull
+    @Override
+    public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
+        UserInformationDTO user = users.get(position);
+        if (convertView == null) {
+            convertView = LayoutInflater.from(getContext()).inflate(R.layout.user_info_card, parent, false);
+        }
+        TextView email= convertView.findViewById(R.id.email);
+        TextView fullName= convertView.findViewById(R.id.first_last_name);
+        Button block=convertView.findViewById(R.id.blockBtn);
+        if(user!=null){
+            email.setText(user.getEmail());
+            fullName.setText(user.getFirstName()+" "+user.getLastName());
+            if(blockedUsersIds.contains(user.getId())){
+                block.setEnabled(false);
+                block.setBackgroundTintList( ColorStateList.valueOf(Color.GRAY));
+                block.setText("Blocked");
+            }else{
+
+                    block.setEnabled(true);
+                    block.setBackgroundTintList(ColorStateList.valueOf(ContextCompat.getColor(block.getContext(), R.color.primary_orange)));
+                    block.setText("Block");
+                    block.setOnClickListener(v -> {
+                        if (listener != null) {
+                            listener.onBlock(user, position);
+                        }
+                    });
+            }
+        }
+
+
+        return  convertView;
+    }
+}

--- a/mobile/app/src/main/java/com/ognjen/fleetforge/api/AdminService.java
+++ b/mobile/app/src/main/java/com/ognjen/fleetforge/api/AdminService.java
@@ -7,6 +7,7 @@ import com.ognjen.fleetforge.dtos.admin.AdminDriverVehicleInfoChangeDTO;
 import com.ognjen.fleetforge.dtos.admin.AdminGetResponseDTO;
 import com.ognjen.fleetforge.dtos.admin.AdminViewDriverChangesResponseDTO;
 import com.ognjen.fleetforge.dtos.admin.AdminViewVehicleChangesResponseDTO;
+import com.ognjen.fleetforge.dtos.admin.BlockUserRequestDTO;
 import com.ognjen.fleetforge.dtos.common.PasswordChangeRequestDTO;
 import com.ognjen.fleetforge.dtos.passenger.PassengerChangeInformationRequestDTO;
 import com.ognjen.fleetforge.dtos.passenger.PassengerChangeInformationResponseDTO;
@@ -47,4 +48,7 @@ public interface AdminService {
 
     @PUT("/api/admin")
     Call<AdminChangeInformationResponseDTO> changeCurrentAdmin(@Body AdminChangeInformationRequestDTO request);
+
+    @PUT("/api/admin/block/{id}")
+    Call<Void> blockUser(@Path("id")Long id, @Body BlockUserRequestDTO requestDTO);
 }

--- a/mobile/app/src/main/java/com/ognjen/fleetforge/api/RetrofitClient.java
+++ b/mobile/app/src/main/java/com/ognjen/fleetforge/api/RetrofitClient.java
@@ -91,4 +91,8 @@ public class RetrofitClient {
     public AuthService getAuthService() {
         return retrofitWithoutAuth.create(AuthService.class);
     }
+
+    public UserService getUserService(){
+        return retrofit.create(UserService.class);
+    }
 }

--- a/mobile/app/src/main/java/com/ognjen/fleetforge/api/UserService.java
+++ b/mobile/app/src/main/java/com/ognjen/fleetforge/api/UserService.java
@@ -1,0 +1,16 @@
+package com.ognjen.fleetforge.api;
+
+import com.ognjen.fleetforge.dtos.admin.GetAllUsersDTO;
+import com.ognjen.fleetforge.dtos.user.GetIsBlockedUserDTO;
+
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Query;
+
+public interface UserService {
+
+    @GET("/api/users")
+    Call<GetAllUsersDTO> getAllUsers(@Query("page") int page, @Query("size") int size, @Query("email") String email);
+    @GET("/api/users/blocked")
+    Call<GetIsBlockedUserDTO> checkIfBlocked();
+}

--- a/mobile/app/src/main/java/com/ognjen/fleetforge/dtos/admin/BlockUserRequestDTO.java
+++ b/mobile/app/src/main/java/com/ognjen/fleetforge/dtos/admin/BlockUserRequestDTO.java
@@ -1,0 +1,13 @@
+package com.ognjen.fleetforge.dtos.admin;
+
+public class BlockUserRequestDTO {
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+
+    private String reason;
+}

--- a/mobile/app/src/main/java/com/ognjen/fleetforge/dtos/admin/GetAllUsersDTO.java
+++ b/mobile/app/src/main/java/com/ognjen/fleetforge/dtos/admin/GetAllUsersDTO.java
@@ -1,0 +1,44 @@
+package com.ognjen.fleetforge.dtos.admin;
+
+import com.ognjen.fleetforge.dtos.user.UserInformationDTO;
+
+import java.util.List;
+
+public class GetAllUsersDTO {
+    private List<UserInformationDTO> content;
+    private boolean first;
+    private boolean last;
+    private int totalPages;
+
+    public List<UserInformationDTO> getContent() {
+        return content;
+    }
+
+    public void setContent(List<UserInformationDTO> content) {
+        this.content = content;
+    }
+
+    public boolean isFirst() {
+        return first;
+    }
+
+    public void setFirst(boolean first) {
+        this.first = first;
+    }
+
+    public boolean isLast() {
+        return last;
+    }
+
+    public void setLast(boolean last) {
+        this.last = last;
+    }
+
+    public int getTotalPages() {
+        return totalPages;
+    }
+
+    public void setTotalPages(int totalPages) {
+        this.totalPages = totalPages;
+    }
+}

--- a/mobile/app/src/main/java/com/ognjen/fleetforge/dtos/user/GetIsBlockedUserDTO.java
+++ b/mobile/app/src/main/java/com/ognjen/fleetforge/dtos/user/GetIsBlockedUserDTO.java
@@ -1,0 +1,22 @@
+package com.ognjen.fleetforge.dtos.user;
+
+public class GetIsBlockedUserDTO {
+    private boolean blocked;
+    private String reason;
+
+    public boolean isBlocked() {
+        return blocked;
+    }
+
+    public void setBlocked(boolean blocked) {
+        this.blocked = blocked;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+}

--- a/mobile/app/src/main/java/com/ognjen/fleetforge/dtos/user/UserInformationDTO.java
+++ b/mobile/app/src/main/java/com/ognjen/fleetforge/dtos/user/UserInformationDTO.java
@@ -1,0 +1,82 @@
+package com.ognjen.fleetforge.dtos.user;
+
+public class UserInformationDTO {
+    private Long id;
+    private String email;
+
+    private String firstName;
+
+    private String lastName;
+
+    private String address;
+
+    private String phoneNumber;
+
+    private String profilePicture;
+
+    private boolean blocked;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public String getProfilePicture() {
+        return profilePicture;
+    }
+
+    public void setProfilePicture(String profilePicture) {
+        this.profilePicture = profilePicture;
+    }
+
+    public boolean isBlocked() {
+        return blocked;
+    }
+
+    public void setBlocked(boolean blocked) {
+        this.blocked = blocked;
+    }
+}

--- a/mobile/app/src/main/java/com/ognjen/fleetforge/fragments/admin/UsersList.java
+++ b/mobile/app/src/main/java/com/ognjen/fleetforge/fragments/admin/UsersList.java
@@ -1,0 +1,180 @@
+package com.ognjen.fleetforge.fragments.admin;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.ListView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import com.ognjen.fleetforge.R;
+import com.ognjen.fleetforge.adapters.UsersListAdatper;
+import com.ognjen.fleetforge.dtos.user.UserInformationDTO;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A simple {@link Fragment} subclass.
+ * Use the {@link UsersList#newInstance} factory method to
+ * create an instance of this fragment.
+ */
+public class UsersList extends Fragment {
+
+    private UsersListViewModel viewModel;
+
+    private UsersListAdatper adapter;
+
+    private ArrayList<UserInformationDTO> users= new ArrayList<>();
+
+    private ListView listView;
+
+    private Set<Long> blockedUsersIds = new HashSet<>();
+
+    private Button nextBtn;
+    private Button prevBtn;
+    private TextView pagination;
+
+    private Button search;
+
+    private TextView searchInput;
+
+
+    public UsersList() {
+        // Required empty public constructor
+    }
+
+    /**
+     * Use this factory method to create a new instance of
+     * this fragment using the provided parameters.
+     *
+     * @param param1 Parameter 1.
+     * @param param2 Parameter 2.
+     * @return A new instance of fragment UsersList.
+     */
+    // TODO: Rename and change types and number of parameters
+    public static UsersList newInstance(String param1, String param2) {
+        return new UsersList();
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        viewModel=new ViewModelProvider(this).get(UsersListViewModel.class);
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.fragment_users_list, container, false);
+        listView=view.findViewById(R.id.user_info_listView);
+
+        adapter= new UsersListAdatper(getContext(),users);
+        initUsers();
+        listView.setAdapter(adapter);
+
+        adapter.setOnActionListener(new UsersListAdatper.OnActionListener() {
+            @Override
+            public void onBlock(UserInformationDTO request, int position) {
+                showBlockDialog(request, position);
+            }
+        });
+
+        nextBtn= view.findViewById(R.id.next_button);
+        prevBtn= view.findViewById(R.id.prev_button);
+        pagination=view.findViewById(R.id.page_info);
+
+        nextBtn.setOnClickListener(v -> loadPage(viewModel.getPage() + 1));
+        prevBtn.setOnClickListener(v -> loadPage(viewModel.getPage() - 1));
+
+        search=view.findViewById(R.id.search_button);
+        searchInput=view.findViewById(R.id.search_input);
+        search.setOnClickListener(v -> {
+            viewModel.getAllUsers(0, viewModel.getSize(), searchInput.getText().toString())
+                    .observe(getViewLifecycleOwner(), response -> {
+                        if (response != null) {
+                            viewModel.setPage(0);
+                            viewModel.setPageCount(response.getTotalPages());
+                            viewModel.setUsers(response.getContent());
+                            updatePagination();
+                        }
+                    });
+        });
+        return view;
+    }
+    private void showBlockDialog(UserInformationDTO user, int position) {
+        EditText input = new EditText(getContext());
+        input.setHint("Enter reason");
+        input.setPadding(48, 24, 48, 24);
+
+        new AlertDialog.Builder(getContext())
+                .setTitle("Block user")
+                .setMessage("Block " + user.getEmail() + "?")
+                .setView(input)
+                .setPositiveButton("Block", (dialog, which) -> {
+                    String reason = input.getText().toString().trim();
+                    if (reason.isEmpty()) {
+                        Toast.makeText(getContext(), "Reason cannot be empty", Toast.LENGTH_SHORT).show();
+                        return;
+                    }
+                    handleBlock(user, position, reason);
+                })
+                .setNegativeButton("Cancel", null)
+                .show();
+    }
+    private void loadPage(int page) {
+        viewModel.getAllUsers(page, viewModel.getSize(), null)
+                .observe(getViewLifecycleOwner(), response -> {
+                    if (response != null) {
+                        viewModel.setPage(page);
+                        viewModel.setPageCount(response.getTotalPages());
+                        viewModel.setUsers(response.getContent());
+                        updatePagination();
+                    }
+                });
+    }
+
+    private void updatePagination() {
+        int current = viewModel.getPage();
+        int total = viewModel.getPageCount();
+        pagination.setText((current + 1) + " / " + total);
+        prevBtn.setEnabled(current > 0);
+        nextBtn.setEnabled(current < total - 1);
+    }
+    private void handleBlock(UserInformationDTO request, int position,String reason){
+        viewModel.blockUser(request.getId(), reason).observe(getViewLifecycleOwner(), response -> {
+            if (response != null) {
+                blockedUsersIds.add(request.getId());
+                adapter.setBlockedUsersIds(blockedUsersIds);
+                adapter.notifyDataSetChanged();
+            }
+        });
+    }
+    private void initUsers() {
+        viewModel.getUsers().observe(getViewLifecycleOwner(), response -> {
+            if (response != null) {
+                users.clear();
+                blockedUsersIds.clear();
+                for (UserInformationDTO user : response) {
+                    users.add(user);
+                    if (user.isBlocked()) {
+                        blockedUsersIds.add(user.getId());
+                    }
+                }
+                adapter.setBlockedUsersIds(blockedUsersIds);
+                adapter.notifyDataSetChanged();
+            }
+        });
+
+        loadPage(0);
+    }
+}

--- a/mobile/app/src/main/java/com/ognjen/fleetforge/fragments/admin/UsersListViewModel.java
+++ b/mobile/app/src/main/java/com/ognjen/fleetforge/fragments/admin/UsersListViewModel.java
@@ -1,0 +1,78 @@
+package com.ognjen.fleetforge.fragments.admin;
+
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+
+import com.ognjen.fleetforge.dtos.user.UserInformationDTO;
+import com.ognjen.fleetforge.dtos.admin.BlockUserRequestDTO;
+import com.ognjen.fleetforge.dtos.admin.GetAllUsersDTO;
+import com.ognjen.fleetforge.repository.AdminRepo;
+import com.ognjen.fleetforge.repository.UsersRepo;
+
+import java.util.List;
+
+public class UsersListViewModel extends ViewModel {
+    private AdminRepo adminRepo;
+    private MutableLiveData<List<UserInformationDTO>> users = new MutableLiveData<>();
+    private int page=0;
+    private int size=3;
+    private int pageCount;
+
+    public int getPage() {
+        return page;
+    }
+
+    public void setPage(int page) {
+        this.page = page;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public void setSize(int size) {
+        this.size = size;
+    }
+
+    public int getPageCount() {
+        return pageCount;
+    }
+
+    public void setPageCount(int pageCount) {
+        this.pageCount = pageCount;
+    }
+
+    public LiveData<List<UserInformationDTO>> getUsers() {
+        return users;
+    }
+
+    public void setUsers(List<UserInformationDTO> users) {
+        this.users.setValue(users);
+    }
+
+    public UsersRepo getRepo() {
+        return repo;
+    }
+
+    public void setRepo(UsersRepo repo) {
+        this.repo = repo;
+    }
+
+    private UsersRepo repo;
+
+    public UsersListViewModel(){
+        repo= new UsersRepo();
+        adminRepo= new AdminRepo();
+    }
+
+    public LiveData<GetAllUsersDTO> getAllUsers(int page, int size,String email){
+        return repo.getAllUsers(page,size,email);
+    }
+
+    public LiveData<Boolean> blockUser(Long id, String reason){
+        BlockUserRequestDTO requestDTO= new BlockUserRequestDTO();
+        requestDTO.setReason(reason);
+        return adminRepo.blockUser(id,requestDTO);
+    }
+}

--- a/mobile/app/src/main/java/com/ognjen/fleetforge/fragments/driver/DriverProfile.java
+++ b/mobile/app/src/main/java/com/ognjen/fleetforge/fragments/driver/DriverProfile.java
@@ -3,6 +3,7 @@ package com.ognjen.fleetforge.fragments.driver;
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
 
+import android.app.AlertDialog;
 import android.content.Intent;
 import android.os.Bundle;
 
@@ -210,7 +211,21 @@ public class DriverProfile extends Fragment {
                 }
             });
         });
+        driverProfileViewModel.checkBlocked().observe(getViewLifecycleOwner(), blockedResponse -> {
+            if (blockedResponse != null && blockedResponse.isBlocked()) {
+                showBlockedDialog(blockedResponse.getReason());
+            }
+        });
         return view;
     }
-
+    private void showBlockedDialog(String reason) {
+        new AlertDialog.Builder(getContext())
+                .setTitle("Account Blocked")
+                .setMessage("Your account is blocked and you cannot be added to rides.\n\nReason: " +
+                        (reason != null && !reason.isEmpty() ? reason : "No reason provided."))
+                .setPositiveButton("OK", null)
+                .setIcon(android.R.drawable.ic_dialog_alert)
+                .setCancelable(false)
+                .show();
+    }
 }

--- a/mobile/app/src/main/java/com/ognjen/fleetforge/fragments/driver/DriverProfileViewModel.java
+++ b/mobile/app/src/main/java/com/ognjen/fleetforge/fragments/driver/DriverProfileViewModel.java
@@ -9,10 +9,12 @@ import androidx.lifecycle.ViewModel;
 import com.ognjen.fleetforge.dtos.driver.DriverGetResponseDTO;
 import com.ognjen.fleetforge.dtos.driver.DriverProfileChangeRequestDTO;
 import com.ognjen.fleetforge.dtos.driver.DriverProfileChangeResponseDTO;
+import com.ognjen.fleetforge.dtos.user.GetIsBlockedUserDTO;
 import com.ognjen.fleetforge.dtos.vehicle.VehicleInformationChangeRequestDTO;
 import com.ognjen.fleetforge.dtos.vehicle.VehicleInformationChangeResponseDTO;
 import com.ognjen.fleetforge.enums.VehicleType;
 import com.ognjen.fleetforge.repository.DriverRepo;
+import com.ognjen.fleetforge.repository.UsersRepo;
 
 import java.io.IOException;
 
@@ -20,8 +22,18 @@ public class DriverProfileViewModel extends ViewModel {
 
     private DriverRepo repo;
     private LiveData<DriverGetResponseDTO> data;
+    private UsersRepo usersRepo;
+    private LiveData<GetIsBlockedUserDTO> blocked;
+
+    public LiveData<GetIsBlockedUserDTO> checkBlocked() {
+        if(blocked==null){
+            blocked=usersRepo.checkIfBlocked();
+        }
+        return blocked;
+    }
     public DriverProfileViewModel(){
         repo= new DriverRepo();
+        usersRepo= new UsersRepo();
     }
     public LiveData<DriverGetResponseDTO> getLoggedDriver(){
         if(data==null){

--- a/mobile/app/src/main/java/com/ognjen/fleetforge/fragments/passenger/RideOrder.java
+++ b/mobile/app/src/main/java/com/ognjen/fleetforge/fragments/passenger/RideOrder.java
@@ -3,6 +3,7 @@
     import static androidx.appcompat.content.res.AppCompatResources.getDrawable;
     import static androidx.core.util.TypedValueCompat.dpToPx;
 
+    import android.app.AlertDialog;
     import android.graphics.Color;
     import android.os.Bundle;
 
@@ -231,6 +232,10 @@
             });
 
             orderBtn.setOnClickListener(v -> {
+                viewModel.checkBlocked().observe(getViewLifecycleOwner(), blockedResponse -> {
+                    if (blockedResponse != null && blockedResponse.isBlocked()) {
+                        showBlockedDialog(blockedResponse.getReason());
+                    } else {
                 if(canOrder()){
                     ArrayList<WaypointRideCreateDTO> coordinates= new ArrayList<>();
                     WaypointRideCreateDTO startWaypoint= new WaypointRideCreateDTO();
@@ -301,12 +306,24 @@
                     Toast.makeText(getContext(),"Form is not valid. Check if all text fields are filled and if all waypoints are selected from dropdown list.",
                             Toast.LENGTH_LONG).show();
                 }
+                    }
+                });
             });
 
             if(getArguments() != null) {
                 populateFromFavoriteRoute();
             }
             return view;
+        }
+
+        private void showBlockedDialog(String reason) {
+            new AlertDialog.Builder(getContext())
+                    .setTitle("Account Blocked")
+                    .setMessage("Your account is blocked and you cannot order a ride.\n\nReason: " +
+                            (reason != null && !reason.isEmpty() ? reason : "No reason provided."))
+                    .setPositiveButton("OK", null)
+                    .setIcon(android.R.drawable.ic_dialog_alert)
+                    .show();
         }
         private void setupAutocomplete(MaterialAutoCompleteTextView field) {
             field.addTextChangedListener(new TextWatcher() {

--- a/mobile/app/src/main/java/com/ognjen/fleetforge/fragments/passenger/RideOrderViewModel.java
+++ b/mobile/app/src/main/java/com/ognjen/fleetforge/fragments/passenger/RideOrderViewModel.java
@@ -11,11 +11,13 @@ import com.ognjen.fleetforge.dtos.photon.PhotonResponse;
 import com.ognjen.fleetforge.dtos.ride.RideCreateRequestDTO;
 import com.ognjen.fleetforge.dtos.ride.RideCreateResponseDTO;
 import com.ognjen.fleetforge.dtos.ride.WaypointRideCreateDTO;
+import com.ognjen.fleetforge.dtos.user.GetIsBlockedUserDTO;
 import com.ognjen.fleetforge.model.CalculatedRoute;
 import com.ognjen.fleetforge.model.GeoPoint;
 import com.ognjen.fleetforge.enums.VehicleType;
 import com.ognjen.fleetforge.repository.RideRepo;
 import com.ognjen.fleetforge.repository.RoutingRepo;
+import com.ognjen.fleetforge.repository.UsersRepo;
 
 
 import java.io.IOException;
@@ -29,6 +31,15 @@ public class RideOrderViewModel extends ViewModel {
     private final MutableLiveData<PhotonResponse> suggestions = new MutableLiveData<>();
     private RoutingService routingService;
     private RideRepo rideRepo;
+    private UsersRepo usersRepo;
+    private LiveData<GetIsBlockedUserDTO> blocked;
+
+    public LiveData<GetIsBlockedUserDTO> checkBlocked() {
+        if(blocked==null){
+            blocked=usersRepo.checkIfBlocked();
+        }
+        return blocked;
+    }
 
     private MutableLiveData<CalculatedRoute> routeData = new MutableLiveData<>();
     public LiveData<CalculatedRoute> getRouteData() { return routeData; }
@@ -40,6 +51,7 @@ public class RideOrderViewModel extends ViewModel {
         }
         routingService= new RoutingService(apiKey);
         rideRepo= new RideRepo();
+        usersRepo= new UsersRepo();
     }
 
 
@@ -83,5 +95,4 @@ public class RideOrderViewModel extends ViewModel {
 
             return rideRepo.createRide(requestDTO);
         }
-
 }

--- a/mobile/app/src/main/java/com/ognjen/fleetforge/repository/AdminRepo.java
+++ b/mobile/app/src/main/java/com/ognjen/fleetforge/repository/AdminRepo.java
@@ -15,6 +15,7 @@ import com.ognjen.fleetforge.dtos.admin.AdminDriverVehicleInfoChangeDTO;
 import com.ognjen.fleetforge.dtos.admin.AdminGetResponseDTO;
 import com.ognjen.fleetforge.dtos.admin.AdminViewDriverChangesResponseDTO;
 import com.ognjen.fleetforge.dtos.admin.AdminViewVehicleChangesResponseDTO;
+import com.ognjen.fleetforge.dtos.admin.BlockUserRequestDTO;
 import com.ognjen.fleetforge.dtos.common.PasswordChangeRequestDTO;
 import com.ognjen.fleetforge.dtos.passenger.PassengerChangeInformationRequestDTO;
 import com.ognjen.fleetforge.dtos.passenger.PassengerChangeInformationResponseDTO;
@@ -220,5 +221,29 @@ public class AdminRepo {
         });
         return data;
 
+    }
+
+    public LiveData<Boolean> blockUser(Long id,BlockUserRequestDTO requestDTO){
+        MutableLiveData<Boolean> data= new MutableLiveData<>();
+        service.blockUser(id,requestDTO).enqueue(new Callback<Void>() {
+            @Override
+            public void onResponse(Call<Void> call, Response<Void> response) {
+                if(response.isSuccessful()){
+                    data.setValue(true);
+                }else{
+                    try {
+                        android.util.Log.e("API_ERROR", "Error body: " + response.errorBody().string());
+                    } catch (Exception e) { e.printStackTrace(); }
+                    data.setValue(false);
+                }
+            }
+
+            @Override
+            public void onFailure(Call<Void> call, Throwable throwable) {
+                android.util.Log.e("API_FAILURE", "Doslo je do greske: ", throwable);
+                data.setValue(false);
+            }
+        });
+        return data;
     }
 }

--- a/mobile/app/src/main/java/com/ognjen/fleetforge/repository/UsersRepo.java
+++ b/mobile/app/src/main/java/com/ognjen/fleetforge/repository/UsersRepo.java
@@ -1,0 +1,70 @@
+package com.ognjen.fleetforge.repository;
+
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+
+import com.ognjen.fleetforge.api.RetrofitClient;
+import com.ognjen.fleetforge.api.UserService;
+import com.ognjen.fleetforge.dtos.admin.GetAllUsersDTO;
+import com.ognjen.fleetforge.dtos.user.GetIsBlockedUserDTO;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class UsersRepo {
+    private UserService service;
+
+    public UsersRepo(){
+        service= RetrofitClient.getInstance().getUserService();
+    }
+
+    public LiveData<GetAllUsersDTO> getAllUsers(int page, int size, String email){
+        MutableLiveData<GetAllUsersDTO> data= new MutableLiveData<>();
+
+        service.getAllUsers(page,size,email).enqueue(new Callback<GetAllUsersDTO>() {
+            @Override
+            public void onResponse(Call<GetAllUsersDTO> call, Response<GetAllUsersDTO> response) {
+                if(response.isSuccessful()){
+                    data.setValue(response.body());
+                }else{
+                    try {
+                        android.util.Log.e("API_ERROR", "Error body: " + response.errorBody().string());
+                    } catch (Exception e) { e.printStackTrace(); }
+                    data.setValue(null);
+                }
+            }
+
+            @Override
+            public void onFailure(Call<GetAllUsersDTO> call, Throwable throwable) {
+                android.util.Log.e("API_FAILURE", "Doslo je do greske: ", throwable);
+                data.setValue(null);
+            }
+        });
+
+        return data;
+    }
+    public LiveData< GetIsBlockedUserDTO> checkIfBlocked(){
+        MutableLiveData<GetIsBlockedUserDTO> data= new MutableLiveData<>();
+        service.checkIfBlocked().enqueue(new Callback<GetIsBlockedUserDTO>() {
+            @Override
+            public void onResponse(Call<GetIsBlockedUserDTO> call, Response<GetIsBlockedUserDTO> response) {
+                if(response.isSuccessful()){
+                    data.setValue(response.body());
+                }else{
+                    try {
+                        android.util.Log.e("API_ERROR", "Error body: " + response.errorBody().string());
+                    } catch (Exception e) { e.printStackTrace(); }
+                    data.setValue(null);
+                }
+            }
+
+            @Override
+            public void onFailure(Call<GetIsBlockedUserDTO> call, Throwable throwable) {
+                android.util.Log.e("API_FAILURE", "Doslo je do greske: ", throwable);
+                data.setValue(null);
+            }
+        });
+        return data;
+    }
+}

--- a/mobile/app/src/main/res/layout/fragment_users_list.xml
+++ b/mobile/app/src/main/res/layout/fragment_users_list.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/user_info_list_layout"
+    android:paddingTop="50dp">
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        >
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_margin="8dp">
+
+            <EditText
+                android:id="@+id/search_input"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:hint="Search email"
+                android:inputType="textEmailAddress"
+                />
+
+            <Button
+                android:id="@+id/search_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Search"
+                android:layout_marginStart="8dp"/>
+
+        </LinearLayout>
+
+
+        <ListView
+            android:layout_marginTop="32dp"
+        android:id="@+id/user_info_listView"
+        android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+        tools:listitem="@layout/user_info_card" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center"
+            android:padding="8dp">
+
+            <Button
+                android:id="@+id/prev_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Previous"/>
+
+            <TextView
+                android:id="@+id/page_info"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="1 / 1"
+                android:layout_marginHorizontal="16dp"
+                android:textSize="16sp"/>
+
+            <Button
+                android:id="@+id/next_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Next"/>
+
+        </LinearLayout>
+
+    </LinearLayout>
+</FrameLayout>

--- a/mobile/app/src/main/res/layout/user_info_card.xml
+++ b/mobile/app/src/main/res/layout/user_info_card.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/driver_profile_info_bg"
+    android:padding="10dp"
+    android:id="@+id/user_card">
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/email"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:text="example@test.com"
+            android:textColor="@color/black"
+            android:textSize="24dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:text="Mitar Miric"
+            android:textColor="@color/black"
+            android:textSize="20dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/email"
+            android:id="@+id/first_last_name"/>
+
+        <Button
+            android:id="@+id/blockBtn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="40dp"
+            android:text="Block"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/first_last_name"
+            />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## feat: User Block UI & Flow — Mobile

### Overview
This PR implements the full user blocking feature for the mobile app — admin users list with block functionality, and blocked user dialogs for passengers and drivers.

### Changes

#### Mobile (Android)
- Added **Users List** screen for admin with:
  - Paginated list of users (3 per page) with next/previous navigation
  - Search by email
  - Block button per user with confirmation dialog and reason input
  - Blocked users visually grayed out and disabled
- Added `UsersListAdapter` with block button listener and view recycling fix
- Added `UsersListViewModel` with `MutableLiveData` for users list and pagination state
- Added `UserService` — Retrofit calls for fetching all users and checking blocked status
- Added `UsersRepo` — repository layer calling `UserService`
- Added **blocked user dialog** on Passenger Ride Order screen — shown when blocked passenger tries to order a ride
- Added **blocked user dialog** on Driver Profile screen — shown when blocked driver opens their profile
- Added Users List page to navigation sidebar
- Added `BlockUserRequestDTO`, `GetAllUsersDTO`, `GetIsBlockedUserDTO`, `UserInformationDTO` DTO classes

#### Closes #283 
#### Closes #284 