### PR TITLE
feat(mobile): Add notifications for ride order and finish ride 

### DIFF
--- a/mobile/app/src/main/java/com/ognjen/fleetforge/activities/MainActivity.java
+++ b/mobile/app/src/main/java/com/ognjen/fleetforge/activities/MainActivity.java
@@ -1,7 +1,9 @@
 package com.ognjen.fleetforge.activities;
 
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
 
@@ -12,6 +14,7 @@ import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 
+import com.ognjen.fleetforge.enums.NotificationType;
 import com.ognjen.fleetforge.fragments.admin.AdminChatFragment;
 import com.ognjen.fleetforge.fragments.admin.AdminHistoryFragment;
 import com.ognjen.fleetforge.fragments.admin.AdminProfile;
@@ -26,7 +29,6 @@ import com.ognjen.fleetforge.R;
 import com.ognjen.fleetforge.fragments.passenger.CurrentRidePassenger;
 import com.ognjen.fleetforge.fragments.passenger.FavoriteRoutes;
 import com.ognjen.fleetforge.fragments.passenger.PassengerChatFragment;
-import com.ognjen.fleetforge.fragments.passenger.PassengerHistoryFragment;
 import com.ognjen.fleetforge.fragments.passenger.PassengerRidesFragment;
 import com.ognjen.fleetforge.fragments.passenger.RideOrder;
 import com.ognjen.fleetforge.fragments.unregistered.UnregisteredFragment;
@@ -36,8 +38,14 @@ import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.ognjen.fleetforge.fragments.driver.DriverProfile;
 import com.ognjen.fleetforge.fragments.passenger.PassengerProfile;
 
+import android.Manifest;
+import android.content.pm.PackageManager;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
+
 public class MainActivity extends AppCompatActivity {
 
+    private static final String TAG = "MainActivity";
     private BottomNavigationView bottomNavigation;
     private AuthManager authManager;
     private UserRole currentRole;
@@ -55,6 +63,10 @@ public class MainActivity extends AppCompatActivity {
         setupBottomNavigation();
         loadInitialFragment();
 
+        requestNotificationPermission();
+
+        handleNotificationIntent(getIntent());
+
         getWindow().setDecorFitsSystemWindows(false);
         View mainView = findViewById(R.id.bottom_navigation).getRootView();
 
@@ -63,6 +75,68 @@ public class MainActivity extends AppCompatActivity {
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);
             return windowInsets;
         });
+    }
+
+    @Override
+    protected void onNewIntent(@NonNull Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        handleNotificationIntent(intent);
+    }
+
+    private void handleNotificationIntent(Intent intent) {
+        if (intent == null) return;
+
+        String notificationTypeStr = intent.getStringExtra("NOTIFICATION_TYPE");
+
+        if (notificationTypeStr != null) {
+            try {
+                NotificationType notificationType = NotificationType.valueOf(notificationTypeStr);
+                navigateBasedOnNotification(notificationType);
+
+                // Clear the extras so we don't handle them again
+                intent.removeExtra("NOTIFICATION_TYPE");
+                intent.removeExtra("RIDE_ID");
+                intent.removeExtra("NOTIFICATION_ID");
+            } catch (IllegalArgumentException e) {
+                Log.e(TAG, "Invalid notification type: " + notificationTypeStr, e);
+            }
+        }
+    }
+
+    private void navigateBasedOnNotification(NotificationType type) {
+        Log.d(TAG, "Navigating based on notification type: " + type);
+
+        Fragment targetFragment = null;
+
+        switch (type) {
+            case RIDE_CREATED:
+            case NO_AVAILABLE_DRIVER:
+                if (currentRole == UserRole.PASSENGER) {
+                    targetFragment = new CurrentRidePassenger();
+                    bottomNavigation.setSelectedItemId(R.id.nav_current_ride);
+                }
+                break;
+
+            case RIDE_COMPLETED:
+            case RIDE_CANCELLED:
+                if (currentRole == UserRole.PASSENGER) {
+                    targetFragment = new PassengerRidesFragment();
+                    bottomNavigation.setSelectedItemId(R.id.nav_history_user);
+                } else if (currentRole == UserRole.DRIVER) {
+                    targetFragment = new DriverHistoryFragment();
+                    bottomNavigation.setSelectedItemId(R.id.nav_history_driver);
+                }
+                break;
+
+            default:
+                Log.d(TAG, "No navigation action for notification type: " + type);
+                return;
+        }
+
+        if (targetFragment != null) {
+            loadFragment(targetFragment);
+        }
     }
 
     private void setupBottomNavigation() {
@@ -165,6 +239,17 @@ public class MainActivity extends AppCompatActivity {
                 .beginTransaction()
                 .replace(R.id.fragment_container, fragment)
                 .commit();
+    }
+
+    private void requestNotificationPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS)
+                    != PackageManager.PERMISSION_GRANTED) {
+                ActivityCompat.requestPermissions(this,
+                        new String[]{Manifest.permission.POST_NOTIFICATIONS},
+                        1001);
+            }
+        }
     }
 
     private void redirectToLogin() {

--- a/mobile/app/src/main/java/com/ognjen/fleetforge/services/WebSocketService.java
+++ b/mobile/app/src/main/java/com/ognjen/fleetforge/services/WebSocketService.java
@@ -3,6 +3,7 @@ package com.ognjen.fleetforge.services;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Intent;
 import android.os.Build;
@@ -12,13 +13,15 @@ import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
 import androidx.lifecycle.MutableLiveData;
 
+import com.ognjen.fleetforge.R;
+import com.ognjen.fleetforge.activities.MainActivity;
 import com.ognjen.fleetforge.dtos.NotificationDTO;
 import com.ognjen.fleetforge.utils.WebSocketManager;
 
 public class WebSocketService  extends Service {
+    private static final String TAG = "WebSocketService";
     private static final int FOREGROUND_ID = 1;
     private static final String CHANNEL_ID = "WS_Notifications";
-    public static final String ACTION_NEW_NOTIFICATION = "com.team18.NEW_NOTIFICATION";
 
     private WebSocketManager webSocketManager;
     public static MutableLiveData<String> messageData = new MutableLiveData<>();
@@ -34,7 +37,7 @@ public class WebSocketService  extends Service {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             NotificationChannel serviceChannel = new NotificationChannel(
                     CHANNEL_ID, "WebSocket Service Channel",
-                    NotificationManager.IMPORTANCE_LOW);
+                    NotificationManager.IMPORTANCE_HIGH);
             NotificationManager manager = getSystemService(NotificationManager.class);
             manager.createNotificationChannel(serviceChannel);
         }
@@ -69,20 +72,38 @@ public class WebSocketService  extends Service {
             });
         }
 
-        return START_STICKY; //pokrenuce se ponovo ako se ubije
+        return START_STICKY;
     }
+
     private void showNotification(NotificationDTO notification) {
+
         NotificationManager notificationManager =
                 (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+
+        Intent intent = new Intent(this, MainActivity.class);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        intent.putExtra("NOTIFICATION_ID", notification.getId());
+        intent.putExtra("NOTIFICATION_TYPE", notification.getType().name());
+        intent.putExtra("RIDE_ID", notification.getRideId());
+
+        PendingIntent pendingIntent = PendingIntent.getActivity(
+                this,
+                Math.toIntExact(notification.getId()),
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
+        );
 
         Notification notif = new NotificationCompat.Builder(this, CHANNEL_ID)
                 .setContentTitle("FleetForge")
                 .setContentText(notification.getMessage())
-                .setSmallIcon(android.R.drawable.ic_dialog_info)
+                .setSmallIcon(R.drawable.ic_notification)
                 .setPriority(NotificationCompat.PRIORITY_HIGH)
                 .setAutoCancel(true)
+                .setContentIntent(pendingIntent)
                 .build();
 
-        notificationManager.notify(Math.toIntExact(notification.getId())+1000, notif);
+        int notificationId = Math.toIntExact(notification.getId()) + 1000;
+        notificationManager.notify(notificationId, notif);
+
     }
 }

--- a/mobile/app/src/main/java/com/ognjen/fleetforge/utils/WebSocketManager.java
+++ b/mobile/app/src/main/java/com/ognjen/fleetforge/utils/WebSocketManager.java
@@ -113,11 +113,14 @@ public class WebSocketManager {
 
     public void subscribeToNotifications() {
         String topicPath = "/user/queue/notifications";
+        Log.d(TAG, "📡 Subscribing to: " + topicPath);
 
         Disposable topic = stomp.topic(topicPath)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(topicMessage -> {
+                    Log.d(TAG, "✅ NOTIFICATION RECEIVED via WebSocket");
+                    Log.d(TAG, "📦 Payload: " + topicMessage.getPayload());
                     handleNotificationMessage(topicMessage.getPayload());
                 }, throwable -> {
                     Log.e(TAG, "❌ Error subscribing to notifications", throwable);
@@ -182,9 +185,8 @@ public class WebSocketManager {
     private void handleNotificationMessage(String payload) {
         try {
             NotificationDTO notification = gson.fromJson(payload, NotificationDTO.class);
-            notificationData.postValue(notification);
         } catch (Exception e) {
-            Log.e(TAG, "Error parsing notification message", e);
+            Log.e(TAG, "❌ Error parsing notification", e);
         }
     }
 

--- a/mobile/app/src/main/res/drawable/ic_notification.xml
+++ b/mobile/app/src/main/res/drawable/ic_notification.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M12,22c1.1,0 2,-0.9 2,-2h-4c0,1.1 0.89,2 2,2zM18,16v-5c0,-3.07 -1.64,-5.64 -4.5,-6.32V4c0,-0.83 -0.67,-1.5 -1.5,-1.5s-1.5,0.67 -1.5,1.5v0.68C7.63,5.36 6,7.92 6,11v5l-2,2v1h16v-1l-2,-2z"/>
+</vector>
+


### PR DESCRIPTION

**Target Branch:** `develop`  
**Source Branch:** `feature/ride-notifications-mobile`

This pull request implements a complete notification system for  mobile application, enabling real-time ride updates via WebSocket and providing seamless navigation from notifications to relevant app screens.

### Changes:
- **WebSocket Integration**: Enhanced `WebSocketService` to receive and display real-time notifications from the backend via STOMP protocol.
- **Notification Click Handling**: Implemented intelligent navigation in `MainActivity` that routes users to appropriate screens based on notification type:
  - `RIDE_CREATED` → Current Ride screen
  - `RIDE_COMPLETED`/`RIDE_CANCELLED` → Ride History screen
  - Includes proper intent handling for both app-opened and app-closed states
- **Notification Display**: 
  - Added PendingIntent support for notification click actions
  - Created notification icon drawable (`ic_notification.xml`)
 
### Closes
- Closes #310 

